### PR TITLE
Add metadata for cargo install

### DIFF
--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -2,6 +2,13 @@
 name = "cargo-anatomy"
 version = "0.1.0"
 edition = "2021"
+description = "Analyze Rust workspaces and report package metrics"
+license = "MIT OR Apache-2.0"
+repository = "https://github.com/cutsea110/cargo-anatomy"
+readme = "../README.md"
+homepage = "https://github.com/cutsea110/cargo-anatomy"
+keywords = ["cargo", "metrics", "analysis", "workspace"]
+categories = ["development-tools", "development-tools::cargo-plugins"]
 
 [dependencies]
 cargo_metadata = "0.15"


### PR DESCRIPTION
## Summary
- add package metadata like description, license and repository to allow `cargo install`

## Testing
- `cargo test --workspace --locked`


------
https://chatgpt.com/codex/tasks/task_b_687584d2c454832b9ed588aac2918f9e