### PR TITLE
Add GitHub Actions workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: Rust CI
+
+on:
+  push:
+  pull_request:
+    branches: [main]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Build
+        run: cargo build --workspace --all-targets --locked
+      - name: Test
+        run: cargo test --workspace --locked


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build and test the workspace
- update the workflow to trigger on pushes to any branch and PRs to main
- use `actions/checkout@v4`

## Testing
- `cargo build --workspace --all-targets --locked`
- `cargo test --workspace --locked`


------
https://chatgpt.com/codex/tasks/task_b_68759654f2c8832bac49bc373e63bc8c