### PR TITLE
Support custom crate source directories

### DIFF
--- a/cargo-anatomy/tests/cli.rs
+++ b/cargo-anatomy/tests/cli.rs
@@ -66,3 +66,26 @@ fn outputs_yaml() {
     assert!(s.contains("foo-bar"));
     assert!(s.contains("- metrics:"));
 }
+
+#[test]
+fn custom_lib_path() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir_all(dir.path().join("foo/app")).unwrap();
+    std::fs::write(
+        dir.path().join("foo/Cargo.toml"),
+        "[package]\nname = \"foo\"\nversion = \"0.1.0\"\n[lib]\npath = \"app/lib.rs\"\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("foo/app/lib.rs"), "pub struct Foo;\n").unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        "[workspace]\nmembers = [\"foo\"]\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("cargo-anatomy").unwrap();
+    cmd.arg("-a").current_dir(dir.path());
+    let out = cmd.assert().get_output().stdout.clone();
+    let s = String::from_utf8_lossy(&out);
+    assert!(s.contains("foo"));
+}


### PR DESCRIPTION
## Summary
- collect crate source files based on `[lib]` or `[[bin]]` paths
- test custom `lib` path handling

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_b_6875d8b1cbc4832b96ca81adce08de7f