### PR TITLE
Switch JSON output to compact form

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ cargo anatomy -V
 cargo anatomy -o yaml
 ```
 
-The command outputs metrics for every member crate in JSON format by default. Use `-o yaml` for YAML output. Example output:
+The command outputs metrics for every member crate in compact JSON format by default. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output. Example output (`| jq`):
 
 ```json
 {

--- a/cargo-anatomy/src/main.rs
+++ b/cargo-anatomy/src/main.rs
@@ -122,7 +122,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
         let out_str = match format.as_str() {
-            "json" => serde_json::to_string_pretty(&vec)?,
+            "json" => serde_json::to_string(&vec)?,
             "yaml" => serde_yaml::to_string(&vec)?,
             other => {
                 eprintln!("unknown output format: {}", other);
@@ -143,7 +143,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
         }
         let out_str = match format.as_str() {
-            "json" => serde_json::to_string_pretty(&out)?,
+            "json" => serde_json::to_string(&out)?,
             "yaml" => serde_yaml::to_string(&out)?,
             other => {
                 eprintln!("unknown output format: {}", other);


### PR DESCRIPTION
## Summary
- remove pretty-printing in the CLI JSON output
- document piping to `jq` for readable formatting

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_687622fc6f50832ba070051d5778e648