### PR TITLE
Prepare release 0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [0.1.0] - 2025-07-16
+### Added
+- Initial release with workspace analysis metrics.

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 cutsea110
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -4,6 +4,12 @@
 
 `cargo-anatomy` analyzes Rust workspaces and calculates metrics inspired by Robert C. Martin's package metrics. Each crate inside the workspace is treated as a package.
 
+## Installation
+
+```
+cargo install cargo-anatomy
+```
+
 ## Metrics
 
 - **N** — number of classes in the crate (`struct`, `enum`, `trait` and `type` definitions).

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -3,7 +3,7 @@ name = "cargo-anatomy"
 version = "0.1.0"
 edition = "2021"
 description = "Analyze Rust workspaces and report package metrics"
-license = "MIT OR Apache-2.0"
+license = "MIT"
 repository = "https://github.com/cutsea110/cargo-anatomy"
 readme = "../README.md"
 homepage = "https://github.com/cutsea110/cargo-anatomy"
@@ -24,3 +24,7 @@ getopts = "0.2"
 [dev-dependencies]
 tempfile = "3"
 assert_cmd = "2"
+
+[[bin]]
+name = "cargo-anatomy"
+path = "src/main.rs"


### PR DESCRIPTION
## Summary
- add installation section in README
- add changelog
- use MIT license exclusively
- specify binary path in Cargo.toml

## Testing
- `cargo test --workspace --locked`


------
https://chatgpt.com/codex/tasks/task_b_6876f55c4fd0832b951e1fd422b55b61