### PR TITLE
Add crates.io and docs.rs badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Rust CI](https://github.com/cutsea110/cargo-anatomy/actions/workflows/ci.yml/badge.svg)](https://github.com/cutsea110/cargo-anatomy/actions/workflows/ci.yml)
 [![Crates.io](https://img.shields.io/crates/v/cargo-anatomy.svg)](https://crates.io/crates/cargo-anatomy)
 [![Crates.io Downloads](https://img.shields.io/crates/d/cargo-anatomy.svg?label=Crates.io&logo=rust)](https://crates.io/crates/cargo-anatomy)
-[![Docs.rs](https://docs.rs/cargo-anatomy/badge.svg)](https://docs.rs/cargo-anatomy)
 
 `cargo-anatomy` analyzes Rust workspaces and calculates metrics inspired by Robert C. Martin's package metrics. Each crate inside the workspace is treated as a package.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,9 @@
 # cargo-anatomy
 
 [![Rust CI](https://github.com/cutsea110/cargo-anatomy/actions/workflows/ci.yml/badge.svg)](https://github.com/cutsea110/cargo-anatomy/actions/workflows/ci.yml)
+[![Crates.io](https://img.shields.io/crates/v/cargo-anatomy.svg)](https://crates.io/crates/cargo-anatomy)
+[![Crates.io Downloads](https://img.shields.io/crates/d/cargo-anatomy.svg?label=Crates.io&logo=rust)](https://crates.io/crates/cargo-anatomy)
+[![Docs.rs](https://docs.rs/cargo-anatomy/badge.svg)](https://docs.rs/cargo-anatomy)
 
 `cargo-anatomy` analyzes Rust workspaces and calculates metrics inspired by Robert C. Martin's package metrics. Each crate inside the workspace is treated as a package.
 

--- a/cargo-anatomy/src/lib.rs
+++ b/cargo-anatomy/src/lib.rs
@@ -61,7 +61,11 @@ pub struct CrateDetail {
 }
 
 pub fn collect_defined(files: &[File]) -> (HashMap<String, ClassKind>, usize) {
-    fn visit_items(items: &[syn::Item], defined: &mut HashMap<String, ClassKind>, abstract_count: &mut usize) {
+    fn visit_items(
+        items: &[syn::Item],
+        defined: &mut HashMap<String, ClassKind>,
+        abstract_count: &mut usize,
+    ) {
         for item in items {
             match item {
                 syn::Item::Struct(item) if !has_test_attr(&item.attrs) => {
@@ -266,11 +270,7 @@ pub fn parse_package(
             if entry.file_type().is_file()
                 && entry.path().extension().map(|s| s == "rs").unwrap_or(false)
             {
-                if entry
-                    .path()
-                    .components()
-                    .any(|c| c.as_os_str() == "tests")
-                {
+                if entry.path().components().any(|c| c.as_os_str() == "tests") {
                     continue;
                 }
                 debug!("parsing {}", entry.path().display());
@@ -809,9 +809,7 @@ impl<'a> DetailVisitor<'a> {
                             .entry(current.clone())
                             .or_default()
                             .insert(name);
-                    } else if let Some(import_root) =
-                        self.imports.get(&name).cloned().flatten()
-                    {
+                    } else if let Some(import_root) = self.imports.get(&name).cloned().flatten() {
                         if self
                             .all_defined
                             .get(&import_root)
@@ -845,10 +843,7 @@ impl<'a> DetailVisitor<'a> {
                     if let Some(seg) = p.path.segments.last() {
                         let name = seg.ident.to_string();
                         if self.defined.contains_key(&name)
-                            || self
-                                .all_defined
-                                .values()
-                                .any(|d| d.contains_key(&name))
+                            || self.all_defined.values().any(|d| d.contains_key(&name))
                         {
                             let root = self.path_root(&p.path);
                             return Some((name, root));
@@ -909,10 +904,7 @@ impl<'a> DetailVisitor<'a> {
                 if let Some(seg) = p.path.segments.last() {
                     let name = seg.ident.to_string();
                     if self.defined.contains_key(&name)
-                        || self
-                            .all_defined
-                            .values()
-                            .any(|d| d.contains_key(&name))
+                        || self.all_defined.values().any(|d| d.contains_key(&name))
                     {
                         let root = self.path_root(&p.path);
                         return Some((name, root));

--- a/cargo-anatomy/src/lib.rs
+++ b/cargo-anatomy/src/lib.rs
@@ -270,6 +270,10 @@ pub fn parse_package(
             if entry.file_type().is_file()
                 && entry.path().extension().map(|s| s == "rs").unwrap_or(false)
             {
+                // Skip integration tests located under `tests/`. Cargo treats files
+                // in this directory as separate crates, so they do not represent
+                // types defined by the package itself.
+                // https://doc.rust-lang.org/cargo/guide/tests.html#integration-tests
                 if entry.path().components().any(|c| c.as_os_str() == "tests") {
                     continue;
                 }


### PR DESCRIPTION
## Summary
- show crates.io package info and docs.rs links in README

## Testing
- `cargo fmt --all -- --check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_687726fc6c54832bb4f527ea2fdd056b