### PR TITLE
Add Dockerfile for multiarch cargo-anatomy

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
+
 .git
-.target
+target
 **/target
 

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,3 @@
-
 .git
 target
 **/target
-

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+.target
+**/target
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: build
-FROM --platform=$BUILDPLATFORM rust:1.75-alpine AS builder
+# Use a recent Rust release to ensure Cargo understands our lock file
+FROM --platform=$BUILDPLATFORM rust:1.87-alpine AS builder
 
 # Install build tools
 RUN apk add --no-cache build-base
@@ -37,7 +38,7 @@ RUN case "$TARGETARCH" in \
     strip /usr/local/bin/cargo-anatomy
 
 # Stage 2: package
-FROM scratch as runtime
+FROM scratch AS runtime
 COPY --from=builder /usr/local/bin/cargo-anatomy /usr/local/bin/
 ENTRYPOINT ["cargo-anatomy"]
 CMD ["-h"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -21,7 +21,9 @@ WORKDIR /app
 # Cache dependencies
 COPY Cargo.toml Cargo.lock ./
 COPY cargo-anatomy/Cargo.toml cargo-anatomy/Cargo.toml
-RUN mkdir -p cargo-anatomy/src && echo 'fn main() {}' > cargo-anatomy/src/main.rs
+# Create a dummy main to build dependencies only
+RUN mkdir -p cargo-anatomy/src \
+    && echo 'fn main() {}' > cargo-anatomy/src/main.rs
 RUN case "$TARGETARCH" in \
         amd64) TARGET=x86_64-unknown-linux-musl ;; \
         arm64) TARGET=aarch64-unknown-linux-musl ;; \
@@ -40,5 +42,5 @@ RUN case "$TARGETARCH" in \
 # Stage 2: package
 FROM scratch AS runtime
 COPY --from=builder /usr/local/bin/cargo-anatomy /usr/local/bin/
-ENTRYPOINT ["cargo-anatomy"]
-CMD ["-h"]
+# Run with help by default
+ENTRYPOINT ["cargo-anatomy", "-h"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 
 # Stage 1: build
 # Build natively for the requested architecture so no cross toolchain is needed
-FROM --platform=$TARGETPLATFORM rust:1.87-alpine AS builder
+FROM rust:1.87-alpine AS builder
 
 # Install build tools
 RUN apk add --no-cache build-base

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,43 @@
+# syntax=docker/dockerfile:1
+
+# Stage 1: build
+FROM --platform=$BUILDPLATFORM rust:1.75-alpine AS builder
+
+# Install build tools
+RUN apk add --no-cache build-base
+
+# Set up target triple based on requested architecture
+ARG TARGETARCH
+RUN case "$TARGETARCH" in \
+    amd64) TARGET=x86_64-unknown-linux-musl ;; \
+    arm64) TARGET=aarch64-unknown-linux-musl ;; \
+    *) echo "Unsupported arch $TARGETARCH" && exit 1 ;; \
+    esac && \
+    rustup target add $TARGET
+
+WORKDIR /app
+
+# Cache dependencies
+COPY Cargo.toml Cargo.lock ./
+COPY cargo-anatomy/Cargo.toml cargo-anatomy/Cargo.toml
+RUN mkdir -p cargo-anatomy/src && echo 'fn main() {}' > cargo-anatomy/src/main.rs
+RUN case "$TARGETARCH" in \
+    amd64) TARGET=x86_64-unknown-linux-musl ;; \
+    arm64) TARGET=aarch64-unknown-linux-musl ;; \
+    esac && \
+    cargo build --release --target $TARGET -p cargo-anatomy
+
+RUN rm -rf cargo-anatomy/src
+COPY . .
+RUN case "$TARGETARCH" in \
+    amd64) TARGET=x86_64-unknown-linux-musl ;; \
+    arm64) TARGET=aarch64-unknown-linux-musl ;; \
+    esac && \
+    cargo install --locked --path cargo-anatomy --target $TARGET --root /usr/local && \
+    strip /usr/local/bin/cargo-anatomy
+
+# Stage 2: package
+FROM scratch as runtime
+COPY --from=builder /usr/local/bin/cargo-anatomy /usr/local/bin/
+ENTRYPOINT ["cargo-anatomy"]
+CMD ["-h"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,12 @@ RUN apk add --no-cache build-base
 
 # Set up musl target based on architecture
 ARG TARGETARCH
-RUN TARGET="${TARGETARCH}-unknown-linux-musl" \
-    && rustup target add "$TARGET"
+RUN case "$TARGETARCH" in \
+        amd64) TARGET=x86_64-unknown-linux-musl ;; \
+        arm64) TARGET=aarch64-unknown-linux-musl ;; \
+        *) echo "Unsupported arch $TARGETARCH" && exit 1 ;; \
+    esac && \
+    rustup target add "$TARGET"
 
 WORKDIR /app
 
@@ -18,13 +22,19 @@ WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY cargo-anatomy/Cargo.toml cargo-anatomy/Cargo.toml
 RUN mkdir -p cargo-anatomy/src && echo 'fn main() {}' > cargo-anatomy/src/main.rs
-RUN TARGET="${TARGETARCH}-unknown-linux-musl" \
-    && cargo build --release --target "$TARGET" -p cargo-anatomy
+RUN case "$TARGETARCH" in \
+        amd64) TARGET=x86_64-unknown-linux-musl ;; \
+        arm64) TARGET=aarch64-unknown-linux-musl ;; \
+    esac && \
+    cargo build --release --target "$TARGET" -p cargo-anatomy
 
 RUN rm -rf cargo-anatomy/src
 COPY . .
-RUN TARGET="${TARGETARCH}-unknown-linux-musl" \
-    && cargo install --locked --path cargo-anatomy --target "$TARGET" --root /usr/local \
+RUN case "$TARGETARCH" in \
+        amd64) TARGET=x86_64-unknown-linux-musl ;; \
+        arm64) TARGET=aarch64-unknown-linux-musl ;; \
+    esac && \
+    cargo install --locked --path cargo-anatomy --target "$TARGET" --root /usr/local \
     && strip /usr/local/bin/cargo-anatomy
 
 # Stage 2: package

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,16 @@
 # syntax=docker/dockerfile:1
 
 # Stage 1: build
-# Use a recent Rust release to ensure Cargo understands our lock file
-FROM --platform=$BUILDPLATFORM rust:1.87-alpine AS builder
+# Build natively for the requested architecture so no cross toolchain is needed
+FROM --platform=$TARGETPLATFORM rust:1.87-alpine AS builder
 
 # Install build tools
 RUN apk add --no-cache build-base
 
-# Set up target triple based on requested architecture
+# Set up musl target based on architecture
 ARG TARGETARCH
-RUN case "$TARGETARCH" in \
-    amd64) TARGET=x86_64-unknown-linux-musl ;; \
-    arm64) TARGET=aarch64-unknown-linux-musl ;; \
-    *) echo "Unsupported arch $TARGETARCH" && exit 1 ;; \
-    esac && \
-    rustup target add $TARGET
+RUN TARGET="${TARGETARCH}-unknown-linux-musl" \
+    && rustup target add "$TARGET"
 
 WORKDIR /app
 
@@ -22,20 +18,14 @@ WORKDIR /app
 COPY Cargo.toml Cargo.lock ./
 COPY cargo-anatomy/Cargo.toml cargo-anatomy/Cargo.toml
 RUN mkdir -p cargo-anatomy/src && echo 'fn main() {}' > cargo-anatomy/src/main.rs
-RUN case "$TARGETARCH" in \
-    amd64) TARGET=x86_64-unknown-linux-musl ;; \
-    arm64) TARGET=aarch64-unknown-linux-musl ;; \
-    esac && \
-    cargo build --release --target $TARGET -p cargo-anatomy
+RUN TARGET="${TARGETARCH}-unknown-linux-musl" \
+    && cargo build --release --target "$TARGET" -p cargo-anatomy
 
 RUN rm -rf cargo-anatomy/src
 COPY . .
-RUN case "$TARGETARCH" in \
-    amd64) TARGET=x86_64-unknown-linux-musl ;; \
-    arm64) TARGET=aarch64-unknown-linux-musl ;; \
-    esac && \
-    cargo install --locked --path cargo-anatomy --target $TARGET --root /usr/local && \
-    strip /usr/local/bin/cargo-anatomy
+RUN TARGET="${TARGETARCH}-unknown-linux-musl" \
+    && cargo install --locked --path cargo-anatomy --target "$TARGET" --root /usr/local \
+    && strip /usr/local/bin/cargo-anatomy
 
 # Stage 2: package
 FROM scratch AS runtime

--- a/README.md
+++ b/README.md
@@ -72,7 +72,6 @@ The command outputs metrics for every member crate in compact JSON format by def
 
 Enable `RUST_LOG=info` to see progress logs during analysis.
 
-
 ## Docker image
 
 Build an image for the current architecture and load it into Docker with
@@ -99,3 +98,4 @@ docker run --rm cargo-anatomy -h
 
 The image contains only the compiled `cargo-anatomy` binary and is based on
 `scratch` for minimal size.
+

--- a/README.md
+++ b/README.md
@@ -75,7 +75,8 @@ Enable `RUST_LOG=info` to see progress logs during analysis.
 
 ## Docker image
 
-A multi-arch Docker image can be built with:
+A multi-arch Docker image can be built with BuildKit, which will compile the
+binary natively for each target architecture:
 
 ```bash
 docker buildx build --platform linux/amd64,linux/arm64 -t cargo-anatomy .

--- a/README.md
+++ b/README.md
@@ -72,3 +72,19 @@ The command outputs metrics for every member crate in compact JSON format by def
 
 Enable `RUST_LOG=info` to see progress logs during analysis.
 
+
+## Docker image
+
+A multi-arch Docker image can be built with:
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t cargo-anatomy .
+```
+
+Run the container with:
+
+```bash
+docker run --rm cargo-anatomy -h
+```
+
+The image contains only the compiled `cargo-anatomy` binary and is based on `scratch` for minimal size.

--- a/README.md
+++ b/README.md
@@ -75,11 +75,18 @@ Enable `RUST_LOG=info` to see progress logs during analysis.
 
 ## Docker image
 
-A multi-arch Docker image can be built with BuildKit, which will compile the
-binary natively for each target architecture:
+Build an image for the current architecture and load it into Docker with
 
 ```bash
-docker buildx build --platform linux/amd64,linux/arm64 -t cargo-anatomy --load .
+docker buildx build --platform <arch> -t cargo-anatomy --load .
+```
+
+Replace `<arch>` with `linux/amd64` on x86_64 machines or `linux/arm64` on
+Arm-based hosts. To publish a multi-platform image, use `--push` instead of
+`--load`:
+
+```bash
+docker buildx build --platform linux/amd64,linux/arm64 -t <your-registry>/cargo-anatomy --push .
 ```
 
 Run the container with:
@@ -88,4 +95,5 @@ Run the container with:
 docker run --rm cargo-anatomy -h
 ```
 
-The image contains only the compiled `cargo-anatomy` binary and is based on `scratch` for minimal size.
+The image contains only the compiled `cargo-anatomy` binary and is based on
+`scratch` for minimal size.

--- a/README.md
+++ b/README.md
@@ -86,8 +86,10 @@ Arm-based hosts. To publish a multi-platform image, use `--push` instead of
 `--load`:
 
 ```bash
-docker buildx build --platform linux/amd64,linux/arm64 -t <your-registry>/cargo-anatomy --push .
+docker buildx build --platform linux/amd64,linux/arm64 \
+    -t <your-registry>/cargo-anatomy:<version> --push .
 ```
+Set `<version>` to the tag for the published image.
 
 Run the container with:
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ A multi-arch Docker image can be built with BuildKit, which will compile the
 binary natively for each target architecture:
 
 ```bash
-docker buildx build --platform linux/amd64,linux/arm64 -t cargo-anatomy .
+docker buildx build --platform linux/amd64,linux/arm64 -t cargo-anatomy --load .
 ```
 
 Run the container with:


### PR DESCRIPTION
## Summary
- provide a `Dockerfile` that builds a static `cargo-anatomy` binary and supports amd64/arm64
- ignore build artefacts in `.dockerignore`
- document how to build and run the image in README

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_b_68777adf9d80832b81f75957d7570a07