### PR TITLE
Fix unused manifest key warning

### DIFF
--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -6,7 +6,6 @@ description = "Analyze Rust workspaces and report package metrics"
 license = "MIT"
 repository = "https://github.com/cutsea110/cargo-anatomy"
 readme = "../README.md"
-changelog = "CHANGELOG.md"
 homepage = "https://github.com/cutsea110/cargo-anatomy"
 keywords = ["cargo", "metrics", "analysis", "workspace"]
 categories = ["development-tools", "development-tools::cargo-plugins"]


### PR DESCRIPTION
## Summary
- remove `package.changelog` key from Cargo manifest

## Testing
- `cargo build`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_6877a6b4537c832b8bce9d4960390e53