### PR TITLE
Refactor output generation in main

### DIFF
--- a/cargo-anatomy/src/main.rs
+++ b/cargo-anatomy/src/main.rs
@@ -45,24 +45,15 @@ fn crate_target_name(pkg: &cargo_metadata::Package) -> String {
         .unwrap_or_else(|| pkg.name.replace('-', "_"))
 }
 
-#[derive(Serialize)]
-struct Output {
-    crate_name: String,
-    metrics: cargo_anatomy::Metrics,
-}
-
 trait IntoOutput: Clone + Serialize {
     type Out: Serialize;
     fn into_output(self, package_name: String) -> Self::Out;
 }
 
 impl IntoOutput for cargo_anatomy::Metrics {
-    type Out = Output;
+    type Out = (String, cargo_anatomy::Metrics);
     fn into_output(self, package_name: String) -> Self::Out {
-        Output {
-            crate_name: package_name,
-            metrics: self,
-        }
+        (package_name, self)
     }
 }
 


### PR DESCRIPTION
## Summary
- unify show-all and metrics branches in `main`
- implement `IntoOutput` trait to convert results
- add `emit_results` helper

## Testing
- `cargo test -q`

------
https://chatgpt.com/codex/tasks/task_b_687828ea8a34832b9d52de5d28fd5ce5