### PR TITLE
Add documentation comments

### DIFF
--- a/cargo-anatomy/src/main.rs
+++ b/cargo-anatomy/src/main.rs
@@ -1,3 +1,4 @@
+//! CLI entry point for the cargo-anatomy tool.
 use cargo_anatomy::{analyze_workspace, analyze_workspace_details, parse_package};
 use env_logger;
 use getopts::Options;


### PR DESCRIPTION
## Summary
- add crate-level and item documentation for cargo doc
- document CLI entrypoint
- remove blank lines between doc comments and items

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_b_6878349c1b0c832b81d6c04ddb718a0e