### PR TITLE
Add Ce assertion for external crate

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,9 @@ cargo anatomy
 # Show detailed class and dependency information
 cargo anatomy -a
 
+# Include external dependencies in metrics
+cargo anatomy -x
+
 # Display help with metric descriptions
 cargo anatomy -?
 
@@ -49,7 +52,7 @@ cargo anatomy -V
 cargo anatomy -o yaml
 ```
 
-The command outputs metrics for every member crate in compact JSON format by default. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output. Example output (`| jq`):
+The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Each crate in the results includes a `kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output. Example output (`| jq`):
 
 ```json
 {

--- a/cargo-anatomy/src/lib.rs
+++ b/cargo-anatomy/src/lib.rs
@@ -39,6 +39,13 @@ pub struct ClassInfo {
     pub kind: ClassKind,
 }
 
+/// Whether a crate is part of the workspace or an external dependency.
+#[derive(Debug, Serialize, Clone, Copy, PartialEq, Eq)]
+pub enum CrateKind {
+    Workspace,
+    External,
+}
+
 /// Metrics describing the coupling and cohesion of a crate.
 #[derive(Debug, Serialize, Clone)]
 pub struct Metrics {
@@ -56,6 +63,7 @@ pub struct Metrics {
 /// Detailed analysis results for a single crate.
 #[derive(Debug, Serialize, Clone)]
 pub struct CrateDetail {
+    pub kind: CrateKind,
     pub metrics: Metrics,
     pub classes: Vec<ClassInfo>,
     pub internal_depends_on: HashMap<String, Vec<String>>, // type -> types it depends on
@@ -530,6 +538,7 @@ pub fn analyze_workspace_details(crates: &[(String, Vec<File>)]) -> HashMap<Stri
         result.insert(
             name.clone(),
             CrateDetail {
+                kind: CrateKind::Workspace,
                 metrics: Metrics {
                     r,
                     n,


### PR DESCRIPTION
## Summary
- update integration test to assert `dep` crate has zero efferent coupling
- recognize external crates in CLI when `-x` is used and label crates with `kind`
- import `HashMap` and `HashSet` at the start of `main.rs`
- document the `-x` flag and `kind` output in README

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_b_687976086f0c832b852567225dd517bc