### PR TITLE
Document -x impact

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ cargo anatomy
 # Show detailed class and dependency information
 cargo anatomy -a
 
-# Include external dependencies in metrics
+# Include external dependencies in metrics (may be slower)
 cargo anatomy -x
 
 # Display help with metric descriptions
@@ -52,7 +52,7 @@ cargo anatomy -V
 cargo anatomy -o yaml
 ```
 
-The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Each crate in the results includes a `kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output. Example output (`| jq`):
+The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. Each crate in the results includes a `kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output. Example output (`| jq`):
 
 ```json
 {

--- a/cargo-anatomy/src/main.rs
+++ b/cargo-anatomy/src/main.rs
@@ -110,7 +110,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     opts.optflag(
         "x",
         "include-external",
-        "Include external dependencies in analysis",
+        "Include external dependencies in analysis (slower)",
     );
     opts.optflag("V", "version", "Show version information");
     opts.optopt("o", "output", "Output format: json or yaml", "FORMAT");


### PR DESCRIPTION
## Summary
- mention the slowdown when using `-x` in README
- add note about the slowdown to the help output

## Testing
- `cargo build --workspace --all-targets --locked`
- `cargo test --workspace --locked`


------
https://chatgpt.com/codex/tasks/task_b_6879c5c2eca4832ba49f2a6f826b9cfc