### PR TITLE
Add schema link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,9 @@ cargo anatomy -V
 cargo anatomy -o yaml
 ```
 
-The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. Each crate in the results includes a `kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output. Example output (`| jq`):
+The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. Each crate in the results includes a `kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output.
+
+See [docs/output-schema.md](https://github.com/cutsea110/cargo-anatomy/blob/main/docs/output-schema.md) for a description of the output schema. Example output (`| jq`):
 
 ```json
 {


### PR DESCRIPTION
## Summary
- link the output schema documentation from README

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_6879d4d615dc832b923c8c39f49dd020