### PR TITLE
Clarify README logo link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # cargo-anatomy
 <p align="center">
-  <img src="logo.svg" alt="Cargo Anatomy Logo" width="200" />
+  <!-- crates.io cannot resolve relative paths for images, so we use an absolute URL (FQDN) -->
+  <img src="https://raw.githubusercontent.com/cutsea110/cargo-anatomy/main/logo.svg" alt="Cargo Anatomy Logo" width="200" />
 </p>
 
 [![Rust CI](https://github.com/cutsea110/cargo-anatomy/actions/workflows/ci.yml/badge.svg)](https://github.com/cutsea110/cargo-anatomy/actions/workflows/ci.yml)


### PR DESCRIPTION
## Summary
- keep crates.io logo loading with an absolute URL
- add an English note explaining why the URL must be FQDN

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_6879fb519fa8832bb3717c5657940185