### PR TITLE
Add qualitative evaluation enums

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-anatomy"
-version = "0.2.0"
+version = "0.3.0-alpha.0"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ See [docs/output-schema.md](https://github.com/cutsea110/cargo-anatomy/blob/main
       "d": 0.24,
       "d_prime": 0.34
     },
+    "evaluation": {
+      "a": "mixed",
+      "h": "low",
+      "i": "unstable",
+      "d_prime": "good"
+    },
     "classes": [
       { "name": "Foo", "kind": "Struct" },
       { "name": "Bar", "kind": "Struct" },

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-anatomy"
-version = "0.2.0"
+version = "0.3.0-alpha.0"
 edition = "2021"
 authors = ["Katsutoshi Itoh"]
 description = "Analyze Rust workspaces and report package metrics"

--- a/docs/output-schema.json
+++ b/docs/output-schema.json
@@ -9,7 +9,7 @@
     "maxItems": 2,
     "items": [
       { "type": "string", "description": "Package name" },
-      { "oneOf": [ { "$ref": "#/definitions/Metrics" }, { "$ref": "#/definitions/CrateDetail" } ] }
+      { "oneOf": [ { "$ref": "#/definitions/MetricsResult" }, { "$ref": "#/definitions/CrateDetail" } ] }
     ]
   },
   "definitions": {
@@ -27,6 +27,26 @@
         "d_prime": { "type": "number", "description": "Normalized distance from main sequence" }
       },
       "required": ["r", "n", "h", "ca", "ce", "a", "i", "d", "d_prime"],
+      "additionalProperties": false
+    },
+    "Evaluation": {
+      "type": "object",
+      "properties": {
+        "a": { "type": "string", "enum": ["abstract", "mixed", "concrete"] },
+        "h": { "type": "string", "enum": ["high", "low"] },
+        "i": { "type": "string", "enum": ["stable", "moderate", "unstable"] },
+        "d_prime": { "type": "string", "enum": ["good", "balanced", "painful", "useless"] }
+      },
+      "required": ["a", "h", "i", "d_prime"],
+      "additionalProperties": false
+    },
+    "MetricsResult": {
+      "type": "object",
+      "properties": {
+        "metrics": { "$ref": "#/definitions/Metrics" },
+        "evaluation": { "$ref": "#/definitions/Evaluation" }
+      },
+      "required": ["metrics", "evaluation"],
       "additionalProperties": false
     },
     "ClassKind": {
@@ -62,6 +82,7 @@
       "properties": {
         "kind": { "$ref": "#/definitions/CrateKind" },
         "metrics": { "$ref": "#/definitions/Metrics" },
+        "evaluation": { "$ref": "#/definitions/Evaluation" },
         "classes": {
           "type": "array",
           "items": { "$ref": "#/definitions/ClassInfo" }
@@ -74,6 +95,7 @@
       "required": [
         "kind",
         "metrics",
+        "evaluation",
         "classes",
         "internal_depends_on",
         "internal_depended_by",

--- a/docs/output-schema.md
+++ b/docs/output-schema.md
@@ -25,6 +25,17 @@ used.
 | `d`     | Distance from the main sequence: `|A + I - 1| / sqrt(2)`. |
 | `d_prime` | Normalized distance from the main sequence: `|A + I - 1|`. |
 
+## Evaluation Object
+
+The results also include qualitative labels derived from the metrics:
+
+| Field | Description |
+|-------|-------------|
+| `a` | "abstract", "mixed" or "concrete" depending on the abstraction ratio. |
+| `h` | "high" or "low" relational cohesion. |
+| `i` | "stable", "moderate" or "unstable" based on instability. |
+| `d_prime` | "good", "balanced", "painful" or "useless" depending on the normalized distance. |
+
 ## CrateDetail Object
 
 The detailed result includes additional fields:
@@ -58,7 +69,13 @@ The following is a shortened example after running `cargo anatomy -a | jq`:
       "a": 0.33,
       "i": 1.0,
       "d": 0.24,
-      "d_prime": 0.34
+    "d_prime": 0.34
+    },
+    "evaluation": {
+      "a": "mixed",
+      "h": "low",
+      "i": "unstable",
+      "d_prime": "good"
     },
     "classes": [
       { "name": "Foo", "kind": "Struct" },


### PR DESCRIPTION
## Summary
- encode evaluation labels with enums and new instability threshold
- update output examples and schema
- bump crate version to 0.3.0-alpha.0

## Testing
- `cargo fmt --all`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_687a0ec512b4832b9853293288c11147