### PR TITLE
Bump version to 0.3.0-rc1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-anatomy"
-version = "0.3.0-alpha.0"
+version = "0.3.0-rc1"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-anatomy"
-version = "0.3.0-alpha.0"
+version = "0.3.0-rc1"
 edition = "2021"
 authors = ["Katsutoshi Itoh"]
 description = "Analyze Rust workspaces and report package metrics"


### PR DESCRIPTION
## Summary
- update the crate version to `0.3.0-rc1`
- update Cargo.lock accordingly

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_687abe0c7684832bbbe473d55490d23c