### PR TITLE
Bump version to 0.3.0-beta.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-anatomy"
-version = "0.3.0-rc1"
+version = "0.3.0-beta.0"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-anatomy"
-version = "0.3.0-rc1"
+version = "0.3.0-beta.0"
 edition = "2021"
 authors = ["Katsutoshi Itoh"]
 description = "Analyze Rust workspaces and report package metrics"


### PR DESCRIPTION
## Summary
- update crate version to 0.3.0-beta.0

## Testing
- `cargo test --quiet`


------
https://chatgpt.com/codex/tasks/task_b_687aec2c7e98832bba785e8fbcbb7176