### PR TITLE
Add evaluation info to help

### DIFF
--- a/cargo-anatomy/src/main.rs
+++ b/cargo-anatomy/src/main.rs
@@ -28,6 +28,15 @@ fn print_help_to(opts: &Options, mut w: impl Write) -> io::Result<()> {
         "  D' - normalized distance: |A + I - 1|",
     ];
     writeln!(w, "{}", metrics.join("\n"))?;
+
+    let evaluation = [
+        "Evaluation:",
+        "  A  - >=0.7 abstract, <=0.3 concrete, otherwise mixed",
+        "  H  - >1.0 high, otherwise low",
+        "  I  - >=0.7 unstable, <=0.3 stable, otherwise moderate",
+        "  D' - <=0.4 good; >=0.6 useless if A+I-1 >= 0 else painful; otherwise balanced",
+    ];
+    writeln!(w, "{}", evaluation.join("\n"))?;
     Ok(())
 }
 

--- a/cargo-anatomy/tests/cli.rs
+++ b/cargo-anatomy/tests/cli.rs
@@ -16,6 +16,7 @@ fn prints_help() {
     let s = String::from_utf8_lossy(&out);
     assert!(s.contains("Usage:"));
     assert!(s.contains("Ce"));
+    assert!(s.contains("Evaluation:"));
 }
 
 #[test]


### PR DESCRIPTION
## Summary
- show evaluation label descriptions in the help output
- test that help output includes evaluation section

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_687af3098818832b93befbc0322909c0