### PR TITLE
Release v0.3.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-anatomy"
-version = "0.3.0-rc3"
+version = "0.3.0"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/cargo-anatomy/CHANGELOG.md
+++ b/cargo-anatomy/CHANGELOG.md
@@ -12,3 +12,11 @@ All notable changes to this project will be documented in this file.
 - Output schema documentation with README link.
 - Clarification of `-x` option impact.
 - Project logo.
+
+## [0.3.0] - 2025-07-19
+### Added
+- Qualitative evaluation labels for metrics.
+- Output schema now uses objects with `crate_name`, `metrics` and `evaluation` fields.
+- File and line number information on errors.
+- Evaluation criteria in help output.
+- Expanded Docker usage documentation.

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-anatomy"
-version = "0.3.0-rc3"
+version = "0.3.0"
 edition = "2021"
 authors = ["Katsutoshi Itoh"]
 description = "Analyze Rust workspaces and report package metrics"


### PR DESCRIPTION
## Summary
- bump version to 0.3.0
- add release notes for v0.3.0

## Testing
- `cargo build --workspace --all-targets --locked`
- `cargo test --workspace --locked`


------
https://chatgpt.com/codex/tasks/task_b_687b0090f178832bb2705969850d5b6c