### PR TITLE
Update crate metadata with CLI categories

### DIFF
--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -8,8 +8,12 @@ license = "MIT"
 repository = "https://github.com/cutsea110/cargo-anatomy"
 readme = "../README.md"
 homepage = "https://github.com/cutsea110/cargo-anatomy"
-keywords = ["cargo", "metrics", "analysis", "workspace"]
-categories = ["development-tools", "development-tools::cargo-plugins"]
+keywords = ["cargo", "metrics", "analysis", "workspace", "cli"]
+categories = [
+    "development-tools",
+    "development-tools::cargo-plugins",
+    "command-line-utilities",
+]
 
 [dependencies]
 cargo_metadata = "0.15"


### PR DESCRIPTION
## Summary
- add `command-line-utilities` category
- add `cli` keyword to highlight that cargo-anatomy is a CLI tool

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_b_687b1e3d6cbc832b8e00b0cb353e0541