### PR TITLE
Refactor DOT output error handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ cargo anatomy -o yaml
 cargo anatomy -o dot
 ```
 
-The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. When the `-a` flag is used, each crate also includes a `details.kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output or `-o dot` for Graphviz.
+The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. When the `-a` flag is used, each crate also includes a `details.kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output or `-o dot` for Graphviz. When using `-o dot`, you can write the graph to a file and convert it with Graphviz: `cargo anatomy -o dot > graph.dot && dot -Tpng graph.dot -o graph.png`.
 
 See [docs/output-schema.md](https://github.com/cutsea110/cargo-anatomy/blob/main/docs/output-schema.md) for a description of the output schema. Example output (`| jq`):
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ cargo anatomy -o yaml
 cargo anatomy -o dot
 ```
 
-The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. When the `-a` flag is used, each crate also includes a `details.kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output or `-o dot` for Graphviz. When using `-o dot`, you can write the graph to a file and convert it with Graphviz: `cargo anatomy -o dot > graph.dot && dot -Tpng graph.dot -o graph.png`. Dependency arrows are labeled with the number of afferent and efferent couples between crates.
+The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. When the `-a` flag is used, each crate also includes a `details.kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output or `-o dot` for Graphviz. When using `-o dot`, you can write the graph to a file and convert it with Graphviz: `cargo anatomy -o dot > graph.dot && dot -Tpng graph.dot -o graph.png`. Dependency arrows are labeled with the efferent couple count from the source crate.
 
 See [docs/output-schema.md](https://github.com/cutsea110/cargo-anatomy/blob/main/docs/output-schema.md) for a description of the output schema. Example output (`| jq`):
 

--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ cargo anatomy -V
 
 # Output in YAML format
 cargo anatomy -o yaml
+# Output in Graphviz DOT format
+cargo anatomy -o dot
 ```
 
-The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. When the `-a` flag is used, each crate also includes a `details.kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output.
+The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. When the `-a` flag is used, each crate also includes a `details.kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output or `-o dot` for Graphviz.
 
 See [docs/output-schema.md](https://github.com/cutsea110/cargo-anatomy/blob/main/docs/output-schema.md) for a description of the output schema. Example output (`| jq`):
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ cargo anatomy -o yaml
 cargo anatomy -o dot
 ```
 
-The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. When the `-a` flag is used, each crate also includes a `details.kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output or `-o dot` for Graphviz. When using `-o dot`, you can write the graph to a file and convert it with Graphviz: `cargo anatomy -o dot > graph.dot && dot -Tpng graph.dot -o graph.png`.
+The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. When the `-a` flag is used, each crate also includes a `details.kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output or `-o dot` for Graphviz. When using `-o dot`, you can write the graph to a file and convert it with Graphviz: `cargo anatomy -o dot > graph.dot && dot -Tpng graph.dot -o graph.png`. Dependency arrows are labeled with the number of afferent and efferent couples between crates.
 
 See [docs/output-schema.md](https://github.com/cutsea110/cargo-anatomy/blob/main/docs/output-schema.md) for a description of the output schema. Example output (`| jq`):
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ cargo anatomy -o yaml
 cargo anatomy -o dot
 ```
 
-The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. When the `-a` flag is used, each crate also includes a `details.kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output or `-o dot` for Graphviz. When using `-o dot`, you can write the graph to a file and convert it with Graphviz: `cargo anatomy -o dot > graph.dot && dot -Tpng graph.dot -o graph.png`. Dependency arrows are labeled with the efferent couple count from the source crate.
+The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. When the `-a` flag is used, each crate also includes a `details.kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output or `-o dot` for Graphviz. When using `-o dot`, you can write the graph to a file and convert it with Graphviz: `cargo anatomy -o dot > graph.dot && dot -Tpng graph.dot -o graph.png`. Dependency arrows are labeled with the efferent couple count from the source crate when the `-a` flag is used.
 
 See [docs/output-schema.md](https://github.com/cutsea110/cargo-anatomy/blob/main/docs/output-schema.md) for a description of the output schema. Example output (`| jq`):
 

--- a/cargo-anatomy/src/main.rs
+++ b/cargo-anatomy/src/main.rs
@@ -100,18 +100,6 @@ mod graphviz_dot {
             .count()
     }
 
-    fn afferent_couples(details: &CrateDetails, dependent: &str) -> usize {
-        let mut set = HashSet::new();
-        for map in details.external_depended_by.values() {
-            if let Some(types) = map.get(dependent) {
-                for ty in types {
-                    set.insert(ty.clone());
-                }
-            }
-        }
-        set.len()
-    }
-
     pub(super) fn to_string(
         root: &OutputRoot<OutputEntry>,
         name_map: &[(String, String)],
@@ -156,10 +144,9 @@ mod graphviz_dot {
                                 continue;
                             }
                             let ec = efferent_couples(src_details, dst);
-                            let ac = afferent_couples(src_details, dst);
                             out.push_str(&format!(
-                                "    \"{}\" -> \"{}\" [label=\"Ca={} Ce={}\"];\n",
-                                src, dst, ac, ec
+                                "    \"{}\" -> \"{}\" [taillabel=\"{}\"];\n",
+                                src, dst, ec
                             ));
                         }
                     }

--- a/cargo-anatomy/src/main.rs
+++ b/cargo-anatomy/src/main.rs
@@ -94,21 +94,19 @@ mod graphviz_dot {
 
     fn efferent_couples(details: &CrateDetails, target: &str) -> usize {
         let mut set = HashSet::new();
-        for map in details.external_depends_on.values() {
-            if let Some(types) = map.get(target) {
-                for ty in types {
-                    set.insert(ty.clone());
-                }
+        for (class, map) in &details.external_depends_on {
+            if map.contains_key(target) {
+                set.insert(class.clone());
             }
         }
         set.len()
     }
 
-    fn afferent_couples(details: &CrateDetails, from: &str) -> usize {
+    fn afferent_couples(details: &CrateDetails, src: &str) -> usize {
         let mut set = HashSet::new();
-        for (ty, crate_map) in &details.external_depended_by {
-            if crate_map.contains_key(from) {
-                set.insert(ty.clone());
+        for (class, map) in &details.external_depends_on {
+            if map.contains_key(src) {
+                set.insert(class.clone());
             }
         }
         set.len()

--- a/cargo-anatomy/src/main.rs
+++ b/cargo-anatomy/src/main.rs
@@ -101,11 +101,15 @@ mod graphviz_dot {
     }
 
     fn afferent_couples(details: &CrateDetails, dependent: &str) -> usize {
-        details
-            .external_depended_by
-            .iter()
-            .filter(|(_, map)| map.contains_key(dependent))
-            .count()
+        let mut set = HashSet::new();
+        for map in details.external_depended_by.values() {
+            if let Some(types) = map.get(dependent) {
+                for ty in types {
+                    set.insert(ty.clone());
+                }
+            }
+        }
+        set.len()
     }
 
     pub(super) fn to_string(

--- a/cargo-anatomy/tests/cli.rs
+++ b/cargo-anatomy/tests/cli.rs
@@ -70,6 +70,31 @@ fn outputs_yaml() {
 }
 
 #[test]
+fn outputs_dot() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir(dir.path().join("foo-bar")).unwrap();
+    std::fs::create_dir(dir.path().join("foo-bar/src")).unwrap();
+    std::fs::write(
+        dir.path().join("foo-bar/Cargo.toml"),
+        "[package]\nname = \"foo-bar\"\nversion = \"0.1.0\"\n[lib]\nname = \"foo_bar\"\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("foo-bar/src/lib.rs"), "pub struct Foo;\n").unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        "[workspace]\nmembers = [\"foo-bar\"]\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("cargo-anatomy").unwrap();
+    cmd.args(["-a", "-o", "dot"]).current_dir(dir.path());
+    let out = cmd.assert().get_output().stdout.clone();
+    let s = String::from_utf8_lossy(&out);
+    assert!(s.contains("digraph"));
+    assert!(s.contains("foo_bar"));
+}
+
+#[test]
 fn custom_lib_path() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(dir.path().join("foo/app")).unwrap();

--- a/cargo-anatomy/tests/cli.rs
+++ b/cargo-anatomy/tests/cli.rs
@@ -243,7 +243,7 @@ fn dot_edge_couples() {
     cmd.args(["-a", "-o", "dot"]).current_dir(dir.path());
     let out = cmd.assert().get_output().stdout.clone();
     let s = String::from_utf8_lossy(&out);
-    assert!(s.contains("\"crate_a\" -> \"crate_b\" [label=\"Ca=1 Ce=2\"]"));
+    assert!(s.contains("\"crate_a\" -> \"crate_b\" [taillabel=\"2\"]"));
 }
 
 #[test]
@@ -277,5 +277,5 @@ fn dot_edge_unique_counts() {
     cmd.args(["-a", "-o", "dot"]).current_dir(dir.path());
     let out = cmd.assert().get_output().stdout.clone();
     let s = String::from_utf8_lossy(&out);
-    assert!(s.contains("\"crate_b\" -> \"crate_a\" [label=\"Ca=0 Ce=1\"]"));
+    assert!(s.contains("\"crate_b\" -> \"crate_a\" [taillabel=\"1\"]"));
 }

--- a/docs/output-schema.md
+++ b/docs/output-schema.md
@@ -1,6 +1,7 @@
 # Output Format Schema
 
 This document describes the JSON/YAML output produced by `cargo anatomy`.
+When using `-o dot`, the tool outputs a Graphviz DOT graph instead which is not detailed here.
 The command prints a single object with two sections:
 
 ```json


### PR DESCRIPTION
## Summary
- support output format for Graphviz DOT.

## Testing
- `cargo test --quiet`
- `cargo fmt --all -- --check`


------
https://chatgpt.com/codex/tasks/task_b_687b427e98b0832b9e395df2e035422f