### PR TITLE
Add Mermaid diagram output

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,9 +63,11 @@ cargo anatomy -V
 cargo anatomy -o yaml
 # Output in Graphviz DOT format
 cargo anatomy -o dot
+# Output in Mermaid format
+cargo anatomy -o mermaid
 ```
 
-The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. When the `-a` flag is used, each crate also includes a `details.kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output or `-o dot` for Graphviz. When using `-o dot`, you can write the graph to a file and convert it with Graphviz: `cargo anatomy -o dot > graph.dot && dot -Tpng graph.dot -o graph.png`. Dependency arrows are labeled with the efferent couple count from the source crate when the `-a` flag is used.
+The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. When the `-a` flag is used, each crate also includes a `details.kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output, `-o dot` for Graphviz or `-o mermaid` for Mermaid diagrams. When using `-o dot`, you can write the graph to a file and convert it with Graphviz: `cargo anatomy -o dot > graph.dot && dot -Tpng graph.dot -o graph.png`. Dependency arrows are labeled with the efferent couple count from the source crate when the `-a` flag is used.
 
 See [docs/output-schema.md](https://github.com/cutsea110/cargo-anatomy/blob/main/docs/output-schema.md) for a description of the output schema. Example output (`| jq`):
 

--- a/cargo-anatomy/src/main.rs
+++ b/cargo-anatomy/src/main.rs
@@ -227,7 +227,7 @@ mod mermaid {
                             let id_dst = sanitize(dst);
                             let ec = efferent_couples(src_details, dst);
                             if label_edges {
-                                out.push_str(&format!("    {} --|{}| {}\n", id_src, ec, id_dst));
+                                out.push_str(&format!("    {} --|{}|--> {}\n", id_src, ec, id_dst));
                             } else {
                                 out.push_str(&format!("    {} --> {}\n", id_src, id_dst));
                             }

--- a/cargo-anatomy/tests/cli.rs
+++ b/cargo-anatomy/tests/cli.rs
@@ -95,6 +95,31 @@ fn outputs_dot() {
 }
 
 #[test]
+fn outputs_mermaid() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir(dir.path().join("foo-bar")).unwrap();
+    std::fs::create_dir(dir.path().join("foo-bar/src")).unwrap();
+    std::fs::write(
+        dir.path().join("foo-bar/Cargo.toml"),
+        "[package]\nname = \"foo-bar\"\nversion = \"0.1.0\"\n[lib]\nname = \"foo_bar\"\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("foo-bar/src/lib.rs"), "pub struct Foo;\n").unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        "[workspace]\nmembers = [\"foo-bar\"]\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("cargo-anatomy").unwrap();
+    cmd.args(["-a", "-o", "mermaid"]).current_dir(dir.path());
+    let out = cmd.assert().get_output().stdout.clone();
+    let s = String::from_utf8_lossy(&out);
+    assert!(s.contains("graph LR"));
+    assert!(s.contains("foo_bar"));
+}
+
+#[test]
 fn custom_lib_path() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(dir.path().join("foo/app")).unwrap();

--- a/docs/output-schema.md
+++ b/docs/output-schema.md
@@ -1,7 +1,7 @@
 # Output Format Schema
 
 This document describes the JSON/YAML output produced by `cargo anatomy`.
-When using `-o dot`, the tool outputs a Graphviz DOT graph instead which is not detailed here.
+When using `-o dot`, the tool outputs a Graphviz DOT graph instead which is not detailed here. The `-o mermaid` option similarly emits a Mermaid diagram.
 The command prints a single object with two sections:
 
 ```json


### PR DESCRIPTION
## Summary
- support `-o mermaid` to print dependency graphs in Mermaid format
- document the new output in README and docs
- test Mermaid output format

## Testing
- `cargo fmt --all`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_687c1cb3c55c832ba0aff1ffbb20942a