### PR TITLE
Bump version to v0.4.0-rc1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -105,7 +105,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-anatomy"
-version = "0.3.0"
+version = "0.4.0-rc1"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-anatomy"
-version = "0.3.0"
+version = "0.4.0-rc1"
 edition = "2021"
 authors = ["Katsutoshi Itoh"]
 description = "Analyze Rust workspaces and report package metrics"


### PR DESCRIPTION
## Summary
- update crate version for `cargo-anatomy` to `0.4.0-rc1`

## Testing
- `cargo check`
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_687c3d826e5c832b94ac928a16a7b141