### PR TITLE
Add parsing tests and refactor helpers

### DIFF
--- a/cargo-anatomy/src/lib.rs
+++ b/cargo-anatomy/src/lib.rs
@@ -420,6 +420,12 @@ fn parse_dir(dir: &std::path::Path) -> Result<Vec<File>, Box<dyn std::error::Err
     Ok(files)
 }
 
+/// Parse all Rust source files belonging to the given package.
+///
+/// Every library or binary target's source directory is scanned and any `.rs`
+/// files found are parsed into `syn::File` structures. Files located under a
+/// `tests` directory are skipped since Cargo treats integration tests as
+/// separate crates.
 pub fn parse_package(
     package: &cargo_metadata::Package,
 ) -> Result<Vec<File>, Box<dyn std::error::Error>> {

--- a/cargo-anatomy/src/lib.rs
+++ b/cargo-anatomy/src/lib.rs
@@ -381,12 +381,8 @@ pub fn collect_trait_bounds(files: &[File]) -> HashMap<String, Vec<String>> {
     map
 }
 /// Parse all Rust source files belonging to the given package.
-pub fn parse_package(
-    package: &cargo_metadata::Package,
-) -> Result<Vec<File>, Box<dyn std::error::Error>> {
-    info!("reading crate {}", package.name);
+fn package_source_dirs(package: &cargo_metadata::Package) -> HashSet<std::path::PathBuf> {
     let manifest_dir = package.manifest_path.parent().unwrap();
-
     let mut dirs = HashSet::new();
     for target in &package.targets {
         if target
@@ -394,8 +390,7 @@ pub fn parse_package(
             .iter()
             .any(|k| matches!(k, cargo_metadata::TargetKind::Lib | cargo_metadata::TargetKind::Bin))
         {
-            let src_path = std::path::Path::new(&target.src_path);
-            if let Some(parent) = src_path.parent() {
+            if let Some(parent) = std::path::Path::new(&target.src_path).parent() {
                 dirs.insert(parent.to_path_buf());
             }
         }
@@ -403,27 +398,35 @@ pub fn parse_package(
     if dirs.is_empty() {
         dirs.insert(manifest_dir.join("src").into());
     }
+    dirs
+}
 
+fn parse_dir(dir: &std::path::Path) -> Result<Vec<File>, Box<dyn std::error::Error>> {
     let mut files = Vec::new();
-    for dir in dirs {
-        for entry in WalkDir::new(dir) {
-            let entry = crate::loc_try!(entry);
-            if entry.file_type().is_file()
-                && entry.path().extension().map(|s| s == "rs").unwrap_or(false)
-            {
-                // Skip integration tests located under `tests/`. Cargo treats files
-                // in this directory as separate crates, so they do not represent
-                // types defined by the package itself.
-                // https://doc.rust-lang.org/cargo/guide/tests.html#integration-tests
-                if entry.path().components().any(|c| c.as_os_str() == "tests") {
-                    continue;
-                }
-                debug!("parsing {}", entry.path().display());
-                let content = crate::loc_try!(fs::read_to_string(entry.path()));
-                let file = crate::loc_try!(syn::parse_file(&content));
-                files.push(file);
+    for entry in WalkDir::new(dir) {
+        let entry = crate::loc_try!(entry);
+        if entry.file_type().is_file()
+            && entry.path().extension().map(|s| s == "rs").unwrap_or(false)
+        {
+            if entry.path().components().any(|c| c.as_os_str() == "tests") {
+                continue;
             }
+            debug!("parsing {}", entry.path().display());
+            let content = crate::loc_try!(fs::read_to_string(entry.path()));
+            let file = crate::loc_try!(syn::parse_file(&content));
+            files.push(file);
         }
+    }
+    Ok(files)
+}
+
+pub fn parse_package(
+    package: &cargo_metadata::Package,
+) -> Result<Vec<File>, Box<dyn std::error::Error>> {
+    info!("reading crate {}", package.name);
+    let mut files = Vec::new();
+    for dir in package_source_dirs(package) {
+        files.extend(parse_dir(&dir)?);
     }
     Ok(files)
 }
@@ -1069,90 +1072,79 @@ impl<'a> DetailVisitor<'a> {
         }
     }
 
-    fn infer_expr_type(&self, expr: &syn::Expr) -> Option<(String, Option<String>)> {
-        match expr {
-            syn::Expr::Call(call) => {
-                if let syn::Expr::Path(p) = &*call.func {
-                    if p.path.segments.len() >= 2 {
-                        let func = p.path.segments.last().unwrap().ident.to_string();
-                        let ty = p.path.segments[p.path.segments.len() - 2].ident.to_string();
-                        if let Some(ret) = self.methods.get(&(ty.clone(), func.clone())) {
-                            let root = self.path_root(&p.path);
-                            return Some((ret.clone(), root));
-                        }
-                    }
-                    if let Some(seg) = p.path.segments.last() {
-                        let name = seg.ident.to_string();
-                        if self.defined.contains_key(&name)
-                            || self.all_defined.values().any(|d| d.contains_key(&name))
-                        {
-                            let root = self.path_root(&p.path);
-                            return Some((name, root));
-                        }
-                    }
+    fn infer_from_call(&self, call: &syn::ExprCall) -> Option<(String, Option<String>)> {
+        if let syn::Expr::Path(p) = &*call.func {
+            if p.path.segments.len() >= 2 {
+                let func = p.path.segments.last().unwrap().ident.to_string();
+                let ty = p.path.segments[p.path.segments.len() - 2].ident.to_string();
+                if let Some(ret) = self.methods.get(&(ty.clone(), func.clone())) {
+                    let root = self.path_root(&p.path);
+                    return Some((ret.clone(), root));
                 }
-                None
             }
-            syn::Expr::MethodCall(mc) => {
-                if let Some((receiver_ty, root)) = self.infer_expr_type(&mc.receiver) {
-                    if let Some(ret) = self
-                        .methods
-                        .get(&(receiver_ty.clone(), mc.method.to_string()))
-                    {
-                        return Some((ret.clone(), root));
-                    }
-                    if let Some(bounds) = self.trait_bounds.get(&receiver_ty) {
-                        let mut found = None;
-                        for b in bounds {
-                            if let Some(ret) = self.methods.get(&(b.clone(), mc.method.to_string()))
-                            {
-                                if found.is_some() {
-                                    return None;
-                                }
-                                found = Some(ret.clone());
-                            }
-                        }
-                        if let Some(ret) = found {
-                            return Some((ret, None));
-                        }
-                    }
-                    return Some((receiver_ty, root));
+            if let Some(seg) = p.path.segments.last() {
+                let name = seg.ident.to_string();
+                if self.defined.contains_key(&name) || self.all_defined.values().any(|d| d.contains_key(&name)) {
+                    let root = self.path_root(&p.path);
+                    return Some((name, root));
                 }
+            }
+        }
+        None
+    }
 
-                // Try to infer from a uniquely named method when receiver type is
-                // unknown. This allows chained calls like `self.inner.dao()`
-                // where `dao` is defined only on a trait.
-                let mut ret = None;
-                for ((_, name), r) in self.methods.iter() {
-                    if name == &mc.method.to_string() {
-                        if ret.is_some() {
-                            // Ambiguous method name
+    fn infer_from_method_call(&self, mc: &syn::ExprMethodCall) -> Option<(String, Option<String>)> {
+        if let Some((receiver_ty, root)) = self.infer_expr_type(&mc.receiver) {
+            if let Some(ret) = self.methods.get(&(receiver_ty.clone(), mc.method.to_string())) {
+                return Some((ret.clone(), root));
+            }
+            if let Some(bounds) = self.trait_bounds.get(&receiver_ty) {
+                let mut found = None;
+                for b in bounds {
+                    if let Some(ret) = self.methods.get(&(b.clone(), mc.method.to_string())) {
+                        if found.is_some() {
                             return None;
                         }
-                        // Returning the trait or type's return type
-                        ret = Some(r.clone());
+                        found = Some(ret.clone());
                     }
                 }
-                ret.map(|r| (r, None))
-            }
-            syn::Expr::Path(p) => {
-                if p.path.segments.len() == 1 && p.path.segments[0].ident == "self" {
-                    return self
-                        .current
-                        .as_ref()
-                        .map(|c| (c.clone(), Some(self.crate_name.to_string())));
+                if let Some(ret) = found {
+                    return Some((ret, None));
                 }
-                if let Some(seg) = p.path.segments.last() {
-                    let name = seg.ident.to_string();
-                    if self.defined.contains_key(&name)
-                        || self.all_defined.values().any(|d| d.contains_key(&name))
-                    {
-                        let root = self.path_root(&p.path);
-                        return Some((name, root));
-                    }
-                }
-                None
             }
+            return Some((receiver_ty, root));
+        }
+        let mut ret = None;
+        for ((_, name), r) in self.methods.iter() {
+            if name == &mc.method.to_string() {
+                if ret.is_some() {
+                    return None;
+                }
+                ret = Some(r.clone());
+            }
+        }
+        ret.map(|r| (r, None))
+    }
+
+    fn infer_from_path(&self, p: &syn::ExprPath) -> Option<(String, Option<String>)> {
+        if p.path.segments.len() == 1 && p.path.segments[0].ident == "self" {
+            return self.current.as_ref().map(|c| (c.clone(), Some(self.crate_name.to_string())));
+        }
+        if let Some(seg) = p.path.segments.last() {
+            let name = seg.ident.to_string();
+            if self.defined.contains_key(&name) || self.all_defined.values().any(|d| d.contains_key(&name)) {
+                let root = self.path_root(&p.path);
+                return Some((name, root));
+            }
+        }
+        None
+    }
+
+    fn infer_expr_type(&self, expr: &syn::Expr) -> Option<(String, Option<String>)> {
+        match expr {
+            syn::Expr::Call(call) => self.infer_from_call(call),
+            syn::Expr::MethodCall(mc) => self.infer_from_method_call(mc),
+            syn::Expr::Path(p) => self.infer_from_path(p),
             _ => None,
         }
     }
@@ -1885,5 +1877,144 @@ mod tests {
         let cyc = &cycles[0];
         assert!(cyc.contains(&"crate_a".to_string()));
         assert!(cyc.contains(&"crate_b".to_string()));
+    }
+
+    #[test]
+    fn parse_package_ignores_tests_dir() {
+        use cargo_metadata::MetadataCommand;
+        let dir = tempfile::tempdir().unwrap();
+        std::fs::create_dir_all(dir.path().join("pkg/src")).unwrap();
+        std::fs::create_dir_all(dir.path().join("pkg/tests")).unwrap();
+        std::fs::write(
+            dir.path().join("pkg/Cargo.toml"),
+            "[package]\nname = \"pkg\"\nversion = \"0.1.0\"\n",
+        )
+        .unwrap();
+        std::fs::write(dir.path().join("pkg/src/lib.rs"), "pub struct Foo;\n").unwrap();
+        std::fs::write(dir.path().join("pkg/tests/integration.rs"), "pub struct Bar;\n").unwrap();
+        let metadata = MetadataCommand::new()
+            .no_deps()
+            .current_dir(dir.path().join("pkg"))
+            .exec()
+            .unwrap();
+        let package = metadata.packages.first().unwrap();
+        let files = parse_package(package).unwrap();
+        assert_eq!(files.len(), 1);
+    }
+
+    #[test]
+    fn path_root_resolves_special_paths() {
+        let defined = std::collections::HashMap::new();
+        let mut ws = std::collections::HashSet::new();
+        ws.insert("my_crate".to_string());
+        let visitor = DetailVisitor {
+            current: None,
+            defined: &defined,
+            crate_name: "my_crate",
+            workspace_crates: &ws,
+            all_defined: &std::collections::HashMap::new(),
+            imports: std::collections::HashMap::new(),
+            internal: std::collections::HashMap::new(),
+            external: std::collections::HashMap::new(),
+            methods: &std::collections::HashMap::new(),
+            trait_bounds: &std::collections::HashMap::new(),
+        };
+        let p: syn::Path = syn::parse_str("self::Foo").unwrap();
+        assert_eq!(visitor.path_root(&p), Some("my_crate".to_string()));
+        let p: syn::Path = syn::parse_str("super::bar::Baz").unwrap();
+        assert_eq!(visitor.path_root(&p), Some("my_crate".to_string()));
+        let p: syn::Path = syn::parse_str("crate::Foo").unwrap();
+        assert_eq!(visitor.path_root(&p), Some("my_crate".to_string()));
+    }
+
+    #[test]
+    fn infer_expr_type_special_paths() {
+        use std::collections::{HashMap, HashSet};
+        let mut defined = HashMap::new();
+        defined.insert("Foo".to_string(), ClassKind::Struct);
+        let mut ws = HashSet::new();
+        ws.insert("my_crate".to_string());
+        let visitor = DetailVisitor {
+            current: Some("Current".to_string()),
+            defined: &defined,
+            crate_name: "my_crate",
+            workspace_crates: &ws,
+            all_defined: &HashMap::new(),
+            imports: HashMap::new(),
+            internal: HashMap::new(),
+            external: HashMap::new(),
+            methods: &HashMap::new(),
+            trait_bounds: &HashMap::new(),
+        };
+        let e: syn::Expr = syn::parse_str("self").unwrap();
+        assert_eq!(
+            visitor.infer_expr_type(&e),
+            Some(("Current".to_string(), Some("my_crate".to_string())))
+        );
+        let e: syn::Expr = syn::parse_str("self::Foo").unwrap();
+        assert_eq!(
+            visitor.infer_expr_type(&e),
+            Some(("Foo".to_string(), Some("my_crate".to_string())))
+        );
+        let e: syn::Expr = syn::parse_str("super::Foo").unwrap();
+        assert_eq!(
+            visitor.infer_expr_type(&e),
+            Some(("Foo".to_string(), Some("my_crate".to_string())))
+        );
+        let e: syn::Expr = syn::parse_str("crate::Foo").unwrap();
+        assert_eq!(
+            visitor.infer_expr_type(&e),
+            Some(("Foo".to_string(), Some("my_crate".to_string())))
+        );
+    }
+
+    #[test]
+    fn detects_multiple_cycles() {
+        let src_a = "use crate_b::B; pub struct A(B);";
+        let src_b = "use crate_a::A; pub struct B(A);";
+        let src_c = "use crate_d::D; pub struct C(D);";
+        let src_d = "use crate_c::C; pub struct D(C);";
+
+        let file_a: syn::File = syn::parse_str(src_a).unwrap();
+        let file_b: syn::File = syn::parse_str(src_b).unwrap();
+        let file_c: syn::File = syn::parse_str(src_c).unwrap();
+        let file_d: syn::File = syn::parse_str(src_d).unwrap();
+
+        let crates = vec![
+            ("crate_a".to_string(), vec![file_a]),
+            ("crate_b".to_string(), vec![file_b]),
+            ("crate_c".to_string(), vec![file_c]),
+            ("crate_d".to_string(), vec![file_d]),
+        ];
+
+        let info = analyze_workspace_details(&crates);
+        let mut cycles = dependency_cycles(&info);
+        cycles.sort_by(|a, b| a[0].cmp(&b[0]));
+        assert_eq!(cycles.len(), 2);
+        assert!(cycles[0].contains(&"crate_a".to_string()));
+        assert!(cycles[0].contains(&"crate_b".to_string()));
+        assert!(cycles[1].contains(&"crate_c".to_string()));
+        assert!(cycles[1].contains(&"crate_d".to_string()));
+    }
+
+    #[test]
+    fn detects_no_cycles() {
+        let src_a = "use crate_b::B; pub struct A(B);";
+        let src_b = "pub struct B;";
+        let src_c = "use crate_b::B; pub struct C(B);";
+
+        let file_a: syn::File = syn::parse_str(src_a).unwrap();
+        let file_b: syn::File = syn::parse_str(src_b).unwrap();
+        let file_c: syn::File = syn::parse_str(src_c).unwrap();
+
+        let crates = vec![
+            ("crate_a".to_string(), vec![file_a]),
+            ("crate_b".to_string(), vec![file_b]),
+            ("crate_c".to_string(), vec![file_c]),
+        ];
+
+        let info = analyze_workspace_details(&crates);
+        let cycles = dependency_cycles(&info);
+        assert!(cycles.is_empty());
     }
 }

--- a/cargo-anatomy/src/main.rs
+++ b/cargo-anatomy/src/main.rs
@@ -7,6 +7,27 @@ use serde::Serialize;
 use std::collections::{HashMap, HashSet};
 use std::io::{self, Write};
 
+const METRICS_HELP: &[&str] = &[
+    "Metrics:",
+    "  N  - number of classes",
+    "  R  - number of internal class relationships",
+    "  H  - relational cohesion: (R + 1)/N",
+    "  Ca - afferent coupling: external classes that depend on this crate",
+    "  Ce - efferent coupling: classes in this crate depending on other workspace crates",
+    "  A  - abstraction: traits / N",
+    "  I  - instability: Ce / (Ce + Ca)",
+    "  D  - distance from main sequence: |A + I - 1| / sqrt(2)",
+    "  D' - normalized distance: |A + I - 1|",
+];
+
+const EVALUATION_HELP: &[&str] = &[
+    "Evaluation:",
+    "  A  - >=0.7 abstract, <=0.3 concrete, otherwise mixed",
+    "  H  - >1.0 high, otherwise low",
+    "  I  - >=0.7 unstable, <=0.3 stable, otherwise moderate",
+    "  D' - <=0.4 good; >=0.6 useless if A+I-1 >= 0 else painful; otherwise balanced",
+];
+
 fn print_help_to(opts: &Options, mut w: impl Write) -> io::Result<()> {
     let brief = format!(
         "cargo-anatomy {}\nUsage: cargo anatomy [options]",
@@ -15,28 +36,9 @@ fn print_help_to(opts: &Options, mut w: impl Write) -> io::Result<()> {
     write!(w, "{}", opts.usage(&brief))?;
     writeln!(w)?;
 
-    let metrics = [
-        "Metrics:",
-        "  N  - number of classes",
-        "  R  - number of internal class relationships",
-        "  H  - relational cohesion: (R + 1)/N",
-        "  Ca - afferent coupling: external classes that depend on this crate",
-        "  Ce - efferent coupling: classes in this crate depending on other workspace crates",
-        "  A  - abstraction: traits / N",
-        "  I  - instability: Ce / (Ce + Ca)",
-        "  D  - distance from main sequence: |A + I - 1| / sqrt(2)",
-        "  D' - normalized distance: |A + I - 1|",
-    ];
-    writeln!(w, "{}", metrics.join("\n"))?;
+    writeln!(w, "{}", METRICS_HELP.join("\n"))?;
 
-    let evaluation = [
-        "Evaluation:",
-        "  A  - >=0.7 abstract, <=0.3 concrete, otherwise mixed",
-        "  H  - >1.0 high, otherwise low",
-        "  I  - >=0.7 unstable, <=0.3 stable, otherwise moderate",
-        "  D' - <=0.4 good; >=0.6 useless if A+I-1 >= 0 else painful; otherwise balanced",
-    ];
-    writeln!(w, "{}", evaluation.join("\n"))?;
+    writeln!(w, "{}", EVALUATION_HELP.join("\n"))?;
     Ok(())
 }
 


### PR DESCRIPTION
## Summary
- add unit tests for `parse_package` ignoring `tests/` dir
- ensure path resolution and cycle detection with new tests
- add CLI helper for workspace creation and test for excluding external crates
- split `DetailVisitor` inference logic into helper methods
- extract help text constants and clean up parsing helpers

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_b_687c580d1e94832bb77441ba001534f2