### PR TITLE
Prepare release v0.4.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-anatomy"
-version = "0.4.0-rc2"
+version = "0.4.0"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/cargo-anatomy/CHANGELOG.md
+++ b/cargo-anatomy/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.0] - 2025-07-20
+### Added
+- Mermaid graph output format.
+- Graphviz graph output format.
+- CLI categories in the manifest for crates.io.
+### Changed
+- Graph edges are hidden unless `-a` is specified.
+- Improved DOT output and couple counting.
+### Fixed
+- Documentation updates and internal refactoring.
+
 ## [0.3.0] - 2025-07-19
 ### Added
 - Qualitative evaluation labels for metrics.

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-anatomy"
-version = "0.4.0-rc2"
+version = "0.4.0"
 edition = "2021"
 authors = ["Katsutoshi Itoh"]
 description = "Analyze Rust workspaces and report package metrics"


### PR DESCRIPTION
## Summary
- bump version to 0.4.0
- document the changes for 0.4.0 in the changelog

## Testing
- `cargo test --all --release`


------
https://chatgpt.com/codex/tasks/task_b_687c6fa2fb64832bb8ab2b974de549c5