### PR TITLE
Update version to 0.5.0-alpha.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-anatomy"
-version = "0.4.0"
+version = "0.5.0-alpha.0"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-anatomy"
-version = "0.4.0"
+version = "0.5.0-alpha.0"
 edition = "2021"
 authors = ["Katsutoshi Itoh"]
 description = "Analyze Rust workspaces and report package metrics"


### PR DESCRIPTION
## Summary
- bump crate version to `0.5.0-alpha.0`

## Testing
- `cargo test -q`


------
https://chatgpt.com/codex/tasks/task_b_687c78f12a6c832b958ceca8da5e05ba