### PR TITLE
Add configurable evaluation thresholds

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -123,6 +123,7 @@ dependencies = [
  "serde_yaml",
  "syn",
  "tempfile",
+ "toml",
  "walkdir",
 ]
 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ cargo anatomy -a
 # Include external dependencies in metrics (may be slower)
 cargo anatomy -x
 
+# Use a custom evaluation config
+cargo anatomy -c config.toml
+
 # Display help with metric descriptions
 cargo anatomy -?
 

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -25,6 +25,7 @@ serde_yaml = "0.9"
 log = "0.4"
 env_logger = "0.11"
 getopts = "0.2"
+toml = "0.8"
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary
- allow specifying a config file with `-c`/`--config`
- parse evaluation thresholds from TOML
- evaluate metrics using custom thresholds
- document `-c` option in README
- add regression test for custom config

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_687c78c5d350832b8414c368b1d290da