### PR TITLE
Add init command for generating config template

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,9 @@ cargo anatomy -x
 # Use a custom evaluation config
 cargo anatomy -c config.toml
 
+# Generate a template config file
+cargo anatomy init
+
 # Display help with metric descriptions
 cargo anatomy -?
 

--- a/cargo-anatomy/tests/cli.rs
+++ b/cargo-anatomy/tests/cli.rs
@@ -479,3 +479,15 @@ fn custom_config_thresholds() {
     assert_eq!(arr[0]["evaluation"]["a"], "abstract");
 }
 
+#[test]
+fn init_creates_config() {
+    let dir = tempfile::tempdir().unwrap();
+    let mut cmd = Command::cargo_bin("cargo-anatomy").unwrap();
+    cmd.arg("init").current_dir(dir.path());
+    cmd.assert().success();
+    let path = dir.path().join("anatomy.conf");
+    assert!(path.exists());
+    let contents = std::fs::read_to_string(path).unwrap();
+    assert!(contents.contains("[evaluation]"));
+    assert!(contents.contains("abstract_min"));
+}


### PR DESCRIPTION
## Summary
- add `cargo anatomy init` subcommand
- generate an `anatomy.conf` template with comments in English
- document new command in README
- test creation of config template

## Testing
- `cargo fmt --all`
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_687c8acb7ce8832b93a07cd64ffd47aa