### PR TITLE
Update version to 0.5.0-rc2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-anatomy"
-version = "0.5.0-rc1"
+version = "0.5.0-rc2"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-anatomy"
-version = "0.5.0-rc1"
+version = "0.5.0-rc2"
 edition = "2021"
 authors = ["Katsutoshi Itoh"]
 description = "Analyze Rust workspaces and report package metrics"


### PR DESCRIPTION
## Summary
- bump package version to `0.5.0-rc2`

## Testing
- `cargo test` *(fails: `cargo: command not found`)*

------
https://chatgpt.com/codex/tasks/task_b_687ca8dc62f8832badc9a3eb80cdef64