### PR TITLE
Fix Mermaid node newlines

### DIFF
--- a/cargo-anatomy/src/main.rs
+++ b/cargo-anatomy/src/main.rs
@@ -200,7 +200,7 @@ mod mermaid {
                 let m = &entry.metrics;
                 let e = &entry.evaluation;
                 out.push_str(&format!(
-                    "    {}[\"{}\\nn={} r={} h={:.2}\\nca={} ce={} a={:.2} i={:.2} d'={:.2}\\nA={:?} H={:?} I={:?} D'={:?}\"]\n",
+                    "    {}[\"{}<br/>n={} r={} h={:.2}<br/>ca={} ce={} a={:.2} i={:.2} d'={:.2}<br/>A={:?} H={:?} I={:?} D'={:?}\"]\n",
                     id,
                     crate_name,
                     m.n,

--- a/cargo-anatomy/tests/cli.rs
+++ b/cargo-anatomy/tests/cli.rs
@@ -144,6 +144,30 @@ fn outputs_mermaid() {
 }
 
 #[test]
+fn mermaid_uses_html_newlines() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir(dir.path().join("pkg")).unwrap();
+    std::fs::create_dir(dir.path().join("pkg/src")).unwrap();
+    std::fs::write(
+        dir.path().join("pkg/Cargo.toml"),
+        "[package]\nname = \"pkg\"\nversion = \"0.1.0\"\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("pkg/src/lib.rs"), "pub struct Foo;\n").unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        "[workspace]\nmembers = [\"pkg\"]\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("cargo-anatomy").unwrap();
+    cmd.args(["-a", "-o", "mermaid"]).current_dir(dir.path());
+    let out = cmd.assert().get_output().stdout.clone();
+    let s = String::from_utf8_lossy(&out);
+    assert!(s.contains("<br/>n="));
+}
+
+#[test]
 fn custom_lib_path() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::create_dir_all(dir.path().join("foo/app")).unwrap();


### PR DESCRIPTION
## Summary
- render newlines in Mermaid node labels using `<br/>`
- add regression test ensuring Mermaid output uses HTML line breaks

## Testing
- `cargo test -- --test-threads=1`

------
https://chatgpt.com/codex/tasks/task_b_687ccbc5a6a4832bb15e00f3650ed37b