### PR TITLE
Release v0.4.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-anatomy"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/cargo-anatomy/CHANGELOG.md
+++ b/cargo-anatomy/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.4.1] - 2025-07-20
+### Fixed
+- Corrected newline handling in Mermaid output boxes.
+
 ## [0.4.0] - 2025-07-20
 ### Added
 - Mermaid graph output format.

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-anatomy"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2021"
 authors = ["Katsutoshi Itoh"]
 description = "Analyze Rust workspaces and report package metrics"


### PR DESCRIPTION
## Summary
- bump version to 0.4.1
- document bug fix in changelog

## Testing
- `cargo test`


------
https://chatgpt.com/codex/tasks/task_b_687ccf339c60832ba648cd59ca547158