### PR TITLE
Bump version to 0.5.0-rc3

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-anatomy"
-version = "0.5.0-rc2"
+version = "0.5.0-rc3"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-anatomy"
-version = "0.5.0-rc2"
+version = "0.5.0-rc3"
 edition = "2021"
 authors = ["Katsutoshi Itoh"]
 description = "Analyze Rust workspaces and report package metrics"


### PR DESCRIPTION
## Summary
- update crate version to 0.5.0-rc3

## Testing
- `cargo test --workspace`

------
https://chatgpt.com/codex/tasks/task_b_687cdbe90624832ba7ed6180b75f7eb1