### PR TITLE
Release 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-anatomy"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See [docs/output-schema.md](https://github.com/cutsea110/cargo-anatomy/blob/main
 ```json
 {
   "meta": {
-    "cargo-anatomy": { "version": "0.5.0", "target": "linux/x86_64" },
+  "cargo-anatomy": { "version": "0.5.1", "target": "linux/x86_64" },
     "config": {
       "evaluation": {
         "abstraction": { "abstract_min": 0.7, "concrete_max": 0.3 },

--- a/cargo-anatomy/CHANGELOG.md
+++ b/cargo-anatomy/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.1] - 2025-07-22
+### Fixed
+- Correctly detect dependencies imported via module paths and aliases.
+
 ## [0.5.0] - 2025-07-21
 ### Added
 - Configurable evaluation thresholds.

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-anatomy"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 authors = ["Katsutoshi Itoh"]
 description = "Analyze Rust workspaces and report package metrics"

--- a/docs/output-schema.md
+++ b/docs/output-schema.md
@@ -69,7 +69,7 @@ The following is a shortened example after running `cargo anatomy -a | jq`:
 ```json
 {
   "meta": {
-    "cargo-anatomy": { "version": "0.5.0", "target": "linux/x86_64" },
+  "cargo-anatomy": { "version": "0.5.1", "target": "linux/x86_64" },
     "config": {
       "evaluation": {
         "abstraction": { "abstract_min": 0.7, "concrete_max": 0.3 },


### PR DESCRIPTION
## Summary
- bump version to 0.5.1
- document fixes for alias import detection
- update example output versions

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_687f4833eb28832b8e5a7dd9b3b22663