### PR TITLE
Release version 0.5.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-anatomy"
-version = "0.5.2-rc1"
+version = "0.5.2"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See [docs/output-schema.md](https://github.com/cutsea110/cargo-anatomy/blob/main
 ```json
 {
   "meta": {
-  "cargo-anatomy": { "version": "0.5.2-rc1", "target": "linux/x86_64" },
+  "cargo-anatomy": { "version": "0.5.2", "target": "linux/x86_64" },
     "config": {
       "evaluation": {
         "abstraction": { "abstract_min": 0.7, "concrete_max": 0.3 },

--- a/cargo-anatomy/CHANGELOG.md
+++ b/cargo-anatomy/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.5.2] - 2025-07-23
+### Fixed
+- Improved workspace dependency detection for glob and macro imports.
+- Resolved issues with type alias dependencies.
+
 ## [0.5.1] - 2025-07-22
 ### Fixed
 - Correctly detect dependencies imported via module paths and aliases.

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-anatomy"
-version = "0.5.2-rc1"
+version = "0.5.2"
 edition = "2021"
 authors = ["Katsutoshi Itoh"]
 description = "Analyze Rust workspaces and report package metrics"

--- a/docs/output-schema.md
+++ b/docs/output-schema.md
@@ -69,7 +69,7 @@ The following is a shortened example after running `cargo anatomy -a | jq`:
 ```json
 {
   "meta": {
-  "cargo-anatomy": { "version": "0.5.2-rc1", "target": "linux/x86_64" },
+  "cargo-anatomy": { "version": "0.5.2", "target": "linux/x86_64" },
     "config": {
       "evaluation": {
         "abstraction": { "abstract_min": 0.7, "concrete_max": 0.3 },


### PR DESCRIPTION
## Summary
- bump version to 0.5.2
- document new release in CHANGELOG
- update README and docs with new version number

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_688048a47690832b9a259b24057d5368