### PR TITLE
Use .anatomy.toml for init

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Enable `RUST_LOG=info` to see progress logs during analysis.
 
 ## Configuration
 
-`cargo-anatomy` looks for a `.anatomy.toml` file at the workspace root to customize how metric values are evaluated. Run `cargo anatomy init` to create a template `anatomy.conf` in the current directory. Pass `-c <FILE>` to use a different configuration. The file is written in TOML and contains the following sections and defaults:
+`cargo-anatomy` looks for a `.anatomy.toml` file at the workspace root to customize how metric values are evaluated. Run `cargo anatomy init` to create a template `.anatomy.toml` in the current directory. Pass `-c <FILE>` to use a different configuration. The file is written in TOML and contains the following sections and defaults:
 
 ```toml
 [evaluation]

--- a/cargo-anatomy/src/main.rs
+++ b/cargo-anatomy/src/main.rs
@@ -388,7 +388,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let args: Vec<String> = std::env::args().collect();
 
     if args.len() > 1 && args[1] == "init" {
-        let path = Path::new("anatomy.conf");
+        let path = Path::new(".anatomy.toml");
         return init_config(path);
     }
 

--- a/cargo-anatomy/tests/cli.rs
+++ b/cargo-anatomy/tests/cli.rs
@@ -531,7 +531,7 @@ fn init_creates_config() {
     let mut cmd = Command::cargo_bin("cargo-anatomy").unwrap();
     cmd.arg("init").current_dir(dir.path());
     cmd.assert().success();
-    let path = dir.path().join("anatomy.conf");
+    let path = dir.path().join(".anatomy.toml");
     assert!(path.exists());
     let contents = std::fs::read_to_string(path).unwrap();
     assert!(contents.contains("[evaluation]"));


### PR DESCRIPTION
## Summary
- create `.anatomy.toml` with `cargo anatomy init`
- document the new default config file
- test for dotfile creation

## Testing
- `cargo test --quiet`

------
https://chatgpt.com/codex/tasks/task_b_68809c26f1b0832bb590bae95b98b3eb