### PR TITLE
Bump version to 0.5.3-alpha.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-anatomy"
-version = "0.5.2"
+version = "0.5.3-alpha.0"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ See [docs/output-schema.md](https://github.com/cutsea110/cargo-anatomy/blob/main
 ```json
 {
   "meta": {
-  "cargo-anatomy": { "version": "0.5.2", "target": "linux/x86_64" },
+  "cargo-anatomy": { "version": "0.5.3-alpha.0", "target": "linux/x86_64" },
     "config": {
       "evaluation": {
         "abstraction": { "abstract_min": 0.7, "concrete_max": 0.3 },

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-anatomy"
-version = "0.5.2"
+version = "0.5.3-alpha.0"
 edition = "2021"
 authors = ["Katsutoshi Itoh"]
 description = "Analyze Rust workspaces and report package metrics"

--- a/docs/output-schema.md
+++ b/docs/output-schema.md
@@ -69,7 +69,7 @@ The following is a shortened example after running `cargo anatomy -a | jq`:
 ```json
 {
   "meta": {
-  "cargo-anatomy": { "version": "0.5.2", "target": "linux/x86_64" },
+  "cargo-anatomy": { "version": "0.5.3-alpha.0", "target": "linux/x86_64" },
     "config": {
       "evaluation": {
         "abstraction": { "abstract_min": 0.7, "concrete_max": 0.3 },


### PR DESCRIPTION
## Summary
- update crate version to `0.5.3-alpha.0`
- update references in README and docs

## Testing
- `cargo test`

------
https://chatgpt.com/codex/tasks/task_b_6880a9dc9900832ba38d63658cd1f5f8