### PR TITLE
Add rustfmt check in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,9 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
+          components: rustfmt
+      - name: Format
+        run: cargo fmt --all -- --check
       - name: Build
         run: cargo build --workspace --all-targets --locked
       - name: Test


### PR DESCRIPTION
## Summary
- run `cargo fmt --all -- --check` in CI
- install the `rustfmt` component before running checks

## Testing
- `cargo fmt --all -- --check`
- `cargo build --workspace --all-targets --locked`
- `cargo test --workspace --locked`


------
https://chatgpt.com/codex/tasks/task_b_6880b1a03690832b84cb5626a803532f