### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,16 @@
+## Code Style
+- Format Rust code with `cargo fmt --all`
+- Enforce linting with `cargo clippy -- -D warnings`
+- Disallow glob imports (e.g. `use crate::*;`)
+
+## Testing
+- Run `cargo test` on every commit
+- Minimum coverage: 90% (e.g. via `cargo tarpaulin`)
+
+## Commit Message
+- Follow Conventional Commits
+- Prefix hotfixes with `fix:` and feature work with `feat:`
+
+## Build
+- Run `cargo build` on every commit
+


### PR DESCRIPTION
## Summary
- add `AGENTS.md` with repo instructions

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings` *(fails: io-other-error, derivable-impls, explicit-auto-deref, etc.)*
- `cargo build`
- `cargo test`
- `cargo tarpaulin --workspace --timeout 120 --out Xml` *(62% coverage)*

------
https://chatgpt.com/codex/tasks/task_b_6880c5dac704832b9a64b519ff9d01bb