### PR TITLE
refactor: remove blank lines in lib.rs

### DIFF
--- a/cargo-anatomy/src/lib.rs
+++ b/cargo-anatomy/src/lib.rs
@@ -1,10 +1,8 @@
 //! Utilities for analyzing Rust crates and computing package metrics.
+use log::{debug, info};
+use serde::{Deserialize, Serialize};
 use std::collections::{HashMap, HashSet};
 use std::fs;
-
-use log::{debug, info};
-
-use serde::{Deserialize, Serialize};
 use std::io;
 use std::panic::Location;
 use syn::{visit::Visit, File};


### PR DESCRIPTION
## Summary
- remove redundant blank lines from `lib.rs`

## Testing
- `cargo build`
- `cargo test --all --no-fail-fast`
- `cargo tarpaulin --out Xml` *(fails coverage < 90%)*

------
https://chatgpt.com/codex/tasks/task_b_6880d73ef388832b9e311163e7879724