### PR TITLE
Add HTML output format

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ cargo anatomy -o yaml
 cargo anatomy -o dot
 # Output in Mermaid format
 cargo anatomy -o mermaid
+# Output in HTML format
+cargo anatomy -o html
 
 # Fail if metrics violate thresholds (experimental)
 cargo anatomy --h-lt 1.1 --d-prime-ge 0.9
@@ -79,7 +81,7 @@ cargo anatomy --h-lt 1.1 --d-prime-ge 0.9
 For custom evaluation thresholds, run `cargo anatomy init` to generate a
 template configuration and pass `-c <FILE>` to load it. See the [Configuration](#configuration) section for more details.
 
-The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. When the `-a` flag is used, each crate also includes a `details.kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output, `-o dot` for Graphviz or `-o mermaid` for Mermaid diagrams. When using `-o dot`, you can write the graph to a file and convert it with Graphviz: `cargo anatomy -o dot > graph.dot && dot -Tpng graph.dot -o graph.png`. Dependency arrows are labeled with the efferent couple count from the source crate when the `-a` flag is used. Graphviz and Mermaid outputs omit dependency edges unless `-a` is supplied, so combining these formats with `-a` is recommended when you want to visualize the graph.
+The command outputs metrics for every member crate in compact JSON format by default. Use `-x` to also analyze external dependencies. Analyzing external crates can significantly increase processing time. When the `-a` flag is used, each crate also includes a `details.kind` field indicating whether it is part of the workspace or an external crate. Pipe to `jq` if you want it pretty printed. Use `-o yaml` for YAML output, `-o dot` for Graphviz, `-o mermaid` for Mermaid diagrams or `-o html` for an interactive HTML graph. When using `-o dot`, you can write the graph to a file and convert it with Graphviz: `cargo anatomy -o dot > graph.dot && dot -Tpng graph.dot -o graph.png`. Dependency arrows are labeled with the efferent couple count from the source crate when the `-a` flag is used. Graphviz and Mermaid outputs omit dependency edges unless `-a` is supplied, so combining these formats with `-a` is recommended when you want to visualize the graph.
 
 See [docs/output-schema.md](https://github.com/cutsea110/cargo-anatomy/blob/main/docs/output-schema.md) for a description of the output schema. Example output (`| jq`):
 

--- a/cargo-anatomy/src/main.rs
+++ b/cargo-anatomy/src/main.rs
@@ -376,15 +376,26 @@ mod html {
 <svg width="800" height="600"></svg>
 <script>
 const graph = __DATA__;
+const labelEdges = __LABEL__;
 const width = 800, height = 600;
 const svg = d3.select('svg');
 const simulation = d3.forceSimulation(graph.nodes)
   .force('link', d3.forceLink(graph.links).id(d => d.id).distance(120))
   .force('charge', d3.forceManyBody().strength(-400))
   .force('center', d3.forceCenter(width / 2, height / 2));
-const link = svg.append('g').selectAll('line')
-  .data(graph.links).enter().append('line')
-  .attr('stroke', '#999');
+const link = svg.append('g').selectAll('g')
+  .data(graph.links)
+  .enter()
+  .append('g');
+link.append('line').attr('stroke', '#999');
+link.append('title').text(d => `Ce: ${d.value}`);
+if (labelEdges) {
+  link.append('text')
+    .attr('font-size', 10)
+    .attr('dy', -4)
+    .attr('fill', '#555')
+    .text(d => d.value);
+}
 const node = svg.append('g').selectAll('g')
   .data(graph.nodes)
   .enter().append('g')
@@ -399,7 +410,7 @@ node.append('text')
   .attr('x', 12)
   .attr('dy', '.35em')
   .text(d => d.label);
-node.append('title').text(d => `${d.label}\nCa: ${d.metrics.ca}\nCe: ${d.metrics.ce}\nA: ${d.metrics.a.toFixed(2)}\nI: ${d.metrics.i.toFixed(2)}\nD': ${d.metrics.d_prime.toFixed(2)}\nH: ${d.metrics.h.toFixed(2)}`);
+node.append('title').text(d => `${d.label}\nN: ${d.metrics.n}\nR: ${d.metrics.r}\nH: ${d.metrics.h.toFixed(2)}\nCa: ${d.metrics.ca}\nCe: ${d.metrics.ce}\nA: ${d.metrics.a.toFixed(2)}\nI: ${d.metrics.i.toFixed(2)}\nD: ${d.metrics.d.toFixed(2)}\nD': ${d.metrics.d_prime.toFixed(2)}`);
 function dragstarted(event, d) {
   if (!event.active) simulation.alphaTarget(0.3).restart();
   d.fx = d.x; d.fy = d.y;
@@ -414,12 +425,19 @@ simulation.on('tick', () => {
       .attr('y1', d => d.source.y)
       .attr('x2', d => d.target.x)
       .attr('y2', d => d.target.y);
+  if (labelEdges) {
+    link.select('text')
+      .attr('x', d => (d.source.x + d.target.x) / 2)
+      .attr('y', d => (d.source.y + d.target.y) / 2);
+  }
   node.attr('transform', d => `translate(${d.x},${d.y})`);
 });
 </script>
 </body>
 </html>"#;
-        let html = template.replace("__DATA__", &data_str);
+        let html = template
+            .replace("__DATA__", &data_str)
+            .replace("__LABEL__", &label_edges.to_string());
         Ok(html)
     }
 }

--- a/cargo-anatomy/src/main.rs
+++ b/cargo-anatomy/src/main.rs
@@ -385,14 +385,21 @@ const simulation = d3.forceSimulation(graph.nodes)
 const link = svg.append('g').selectAll('line')
   .data(graph.links).enter().append('line')
   .attr('stroke', '#999');
-const node = svg.append('g').selectAll('circle')
-  .data(graph.nodes).enter().append('circle')
-  .attr('r', 8).attr('fill', '#69b3a2')
+const node = svg.append('g').selectAll('g')
+  .data(graph.nodes)
+  .enter().append('g')
   .call(d3.drag()
       .on('start', dragstarted)
       .on('drag', dragged)
       .on('end', dragended));
-node.append('title').text(d => d.label);
+node.append('circle')
+  .attr('r', 8)
+  .attr('fill', '#69b3a2');
+node.append('text')
+  .attr('x', 12)
+  .attr('dy', '.35em')
+  .text(d => d.label);
+node.append('title').text(d => `${d.label}\nCa: ${d.metrics.ca}\nCe: ${d.metrics.ce}\nA: ${d.metrics.a.toFixed(2)}\nI: ${d.metrics.i.toFixed(2)}\nD': ${d.metrics.d_prime.toFixed(2)}\nH: ${d.metrics.h.toFixed(2)}`);
 function dragstarted(event, d) {
   if (!event.active) simulation.alphaTarget(0.3).restart();
   d.fx = d.x; d.fy = d.y;
@@ -407,7 +414,7 @@ simulation.on('tick', () => {
       .attr('y1', d => d.source.y)
       .attr('x2', d => d.target.x)
       .attr('y2', d => d.target.y);
-  node.attr('cx', d => d.x).attr('cy', d => d.y);
+  node.attr('transform', d => `translate(${d.x},${d.y})`);
 });
 </script>
 </body>

--- a/cargo-anatomy/tests/cli.rs
+++ b/cargo-anatomy/tests/cli.rs
@@ -144,6 +144,31 @@ fn outputs_mermaid() {
 }
 
 #[test]
+fn outputs_html() {
+    let dir = tempfile::tempdir().unwrap();
+    std::fs::create_dir(dir.path().join("foo-bar")).unwrap();
+    std::fs::create_dir(dir.path().join("foo-bar/src")).unwrap();
+    std::fs::write(
+        dir.path().join("foo-bar/Cargo.toml"),
+        "[package]\nname = \"foo-bar\"\nversion = \"0.1.0\"\n[lib]\nname = \"foo_bar\"\n",
+    )
+    .unwrap();
+    std::fs::write(dir.path().join("foo-bar/src/lib.rs"), "pub struct Foo;\n").unwrap();
+    std::fs::write(
+        dir.path().join("Cargo.toml"),
+        "[workspace]\nmembers = [\"foo-bar\"]\n",
+    )
+    .unwrap();
+
+    let mut cmd = Command::cargo_bin("cargo-anatomy").unwrap();
+    cmd.args(["-a", "-o", "html"]).current_dir(dir.path());
+    let out = cmd.assert().get_output().stdout.clone();
+    let s = String::from_utf8_lossy(&out);
+    assert!(s.contains("<!DOCTYPE html>"));
+    assert!(s.contains("foo_bar"));
+}
+
+#[test]
 fn mermaid_uses_html_newlines() {
     let dir = tempfile::tempdir().unwrap();
     std::fs::create_dir(dir.path().join("pkg")).unwrap();

--- a/docs/output-schema.md
+++ b/docs/output-schema.md
@@ -1,7 +1,7 @@
 # Output Format Schema
 
 This document describes the JSON/YAML output produced by `cargo anatomy`.
-When using `-o dot`, the tool outputs a Graphviz DOT graph instead which is not detailed here. The `-o mermaid` option similarly emits a Mermaid diagram.
+When using `-o dot`, the tool outputs a Graphviz DOT graph instead which is not detailed here. The `-o mermaid` option similarly emits a Mermaid diagram. The `-o html` option outputs an interactive HTML graph.
 The command prints a single object with three sections:
 
 ```json


### PR DESCRIPTION
## Summary
- implement `-o html` for interactive graph output using D3.js
- document the new output mode in README and output schema docs
- test HTML output in CLI tests

## Testing
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo test`
- `cargo tarpaulin -o Xml` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_b_68853f8ddeb0832b83c360f68c0ef716