### PR TITLE
Add GitHub Actions template

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,3 +193,32 @@ Set `<version>` to the tag for the published image. After building or pulling an
 image, run it as shown above. The runtime uses a distroless base for a smaller
 footprint.
 
+
+## GitHub Actions
+
+You can integrate `cargo-anatomy` in your CI pipeline. The example below installs
+`cargo-anatomy` and fails the job when metrics do not satisfy the configured thresholds.
+
+```yaml
+# .github/workflows/anatomy.yml
+name: cargo-anatomy
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+
+jobs:
+  analyze:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-rust@v1
+        with:
+          rust-version: stable
+      - name: Install cargo-anatomy
+        run: cargo install cargo-anatomy
+      - name: Run cargo-anatomy
+        run: cargo anatomy -c .anatomy.toml --h-lt 1.1 --d-prime-ge 0.9
+```
+


### PR DESCRIPTION
## Summary
- document how to run `cargo-anatomy` in GitHub Actions

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo build --workspace --all-targets --locked`
- `cargo test --workspace --locked`
- `cargo tarpaulin --workspace --locked --out Xml` *(61.89% coverage)*


------
https://chatgpt.com/codex/tasks/task_b_6885cc3b5bcc832bb2df898d0f323757