### PR TITLE
Update GitHub Actions docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,9 @@ footprint.
 
 You can integrate `cargo-anatomy` in your CI pipeline. The example below installs
 `cargo-anatomy` and fails the job when metrics do not satisfy the configured thresholds.
+Make sure a `.anatomy.toml` file is present in your repository so the workflow
+can load your evaluation settings. You can generate a template with
+`cargo anatomy init` and commit it to version control.
 
 ```yaml
 # .github/workflows/anatomy.yml


### PR DESCRIPTION
## Summary
- clarify that `.anatomy.toml` must be committed when using the GitHub Actions template

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo build --workspace --all-targets --locked`
- `cargo test --workspace --locked`
- `cargo tarpaulin --workspace --timeout 120 --out Xml` *(fails coverage >= 90%)*

------
https://chatgpt.com/codex/tasks/task_b_6885d7da62b8832b9694b34c3f075e59