### PR TITLE
Fix Clap args to support 'cargo anatomy'

### DIFF
--- a/cargo-anatomy/src/main.rs
+++ b/cargo-anatomy/src/main.rs
@@ -531,6 +531,9 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .format_line_number(true)
         .init();
 
+    // When invoked as a cargo subcommand ("cargo anatomy"), cargo passes
+    // "anatomy" as the first argument to this binary. Strip that token so
+    // clap only sees the actual options provided by the user.
     let mut args: Vec<std::ffi::OsString> = std::env::args_os().collect();
     if args.get(1).map(|a| a == "anatomy").unwrap_or(false) {
         args.remove(1);

--- a/cargo-anatomy/src/main.rs
+++ b/cargo-anatomy/src/main.rs
@@ -530,6 +530,12 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .format_source_path(true)
         .format_line_number(true)
         .init();
+
+    let mut args: Vec<std::ffi::OsString> = std::env::args_os().collect();
+    if args.get(1).map(|a| a == "anatomy").unwrap_or(false) {
+        args.remove(1);
+    }
+
     let matches = Command::new("cargo-anatomy")
         .version(env!("CARGO_PKG_VERSION"))
         .disable_help_flag(true)
@@ -617,7 +623,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .visible_short_alias('?')
                 .help("Show this help message"),
         )
-        .get_matches();
+        .get_matches_from(args);
 
     if let Some(("init", sub_m)) = matches.subcommand() {
         let path = sub_m


### PR DESCRIPTION
## Summary
- support invoking the binary as `cargo anatomy`

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo test`
- `cargo tarpaulin --workspace --out Xml` *(fails coverage: 55.94%)*

------
https://chatgpt.com/codex/tasks/task_b_68899e7cbe50832b9326d20bb613ff73