### PR TITLE
feat: bump version to 0.6.0-rc2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-anatomy"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See [docs/output-schema.md](https://github.com/cutsea110/cargo-anatomy/blob/main
 ```json
 {
   "meta": {
-  "cargo-anatomy": { "version": "0.6.0-rc1", "target": "linux/x86_64" },
+  "cargo-anatomy": { "version": "0.6.0-rc2", "target": "linux/x86_64" },
     "config": {
       "evaluation": {
         "abstraction": { "abstract_min": 0.7, "concrete_max": 0.3 },

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-anatomy"
-version = "0.6.0-rc1"
+version = "0.6.0-rc2"
 edition = "2021"
 authors = ["Katsutoshi Itoh"]
 description = "Analyze Rust workspaces and report package metrics"

--- a/docs/output-schema.md
+++ b/docs/output-schema.md
@@ -69,7 +69,7 @@ The following is a shortened example after running `cargo anatomy -a | jq`:
 ```json
 {
   "meta": {
-  "cargo-anatomy": { "version": "0.6.0-rc1", "target": "linux/x86_64" },
+  "cargo-anatomy": { "version": "0.6.0-rc2", "target": "linux/x86_64" },
     "config": {
       "evaluation": {
         "abstraction": { "abstract_min": 0.7, "concrete_max": 0.3 },


### PR DESCRIPTION
## Summary
- bump version to `0.6.0-rc2`
- update documentation references

## Testing
- `cargo build`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo tarpaulin --out Xml` *(fails coverage: 56.18% < 90%)*

------
https://chatgpt.com/codex/tasks/task_b_68899d28e0a8832b85c49e5aa35d1a1a