### PR TITLE
fix: update builder image to rust 1.88-slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@
 # Stage 1: build
 # Use the slim Debian image. Buildx will pull the correct variant for the
 # requested architecture so multi-arch images still work.
-FROM rust:1.87-slim AS builder
+FROM rust:1.88-slim AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Summary
- update Docker builder to `rust:1.88-slim`

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo test`
- `cargo tarpaulin --timeout 120` *(fails: coverage 55.94% < 90%)*

------
https://chatgpt.com/codex/tasks/task_b_6889d487ed58832bb70b01251aab8d42