### PR TITLE
fix: handle reexports when recording dependencies

### DIFF
--- a/cargo-anatomy/src/lib.rs
+++ b/cargo-anatomy/src/lib.rs
@@ -1250,6 +1250,20 @@ impl<'a> DetailVisitor<'a> {
                         .entry(current.clone())
                         .or_default()
                         .insert(name);
+                } else if let Some((Some(import_root), orig)) = self.imports.get(&name).cloned() {
+                    let lookup = orig.unwrap_or(name.clone());
+                    if self
+                        .all_defined
+                        .get(&import_root)
+                        .is_some_and(|d| d.contains_key(&lookup))
+                    {
+                        self.external
+                            .entry(current.clone())
+                            .or_default()
+                            .entry(import_root)
+                            .or_default()
+                            .insert(lookup);
+                    }
                 }
             }
             Some(ref r) => {


### PR DESCRIPTION
## Summary
- fix dependency recording to account for names re-exported from other crates

## Testing
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo test`
- `cargo tarpaulin --ignore-tests --workspace --timeout 120`

------
https://chatgpt.com/codex/tasks/task_b_688a0ede37e4832baa5f5d2e5ff70927