### PR TITLE
Remove __crate_root from outputs

### DIFF
--- a/cargo-anatomy/src/lib.rs
+++ b/cargo-anatomy/src/lib.rs
@@ -806,20 +806,42 @@ pub fn analyze_workspace_details_with_thresholds(
 
         let to_vec_map = |map: &HashMap<String, HashSet<String>>| {
             map.iter()
-                .map(|(k, v)| (k.clone(), v.iter().cloned().collect::<Vec<_>>()))
+                .filter(|(k, _)| *k != DetailVisitor::ROOT_ITEM)
+                .map(|(k, v)| {
+                    (
+                        k.clone(),
+                        v.iter()
+                            .filter(|t| *t != DetailVisitor::ROOT_ITEM)
+                            .cloned()
+                            .collect::<Vec<_>>(),
+                    )
+                })
+                .filter(|(_, v): &(_, Vec<String>)| !v.is_empty())
                 .collect::<HashMap<_, _>>()
         };
 
         let to_vec_nested = |map: &HashMap<String, HashMap<String, HashSet<String>>>| {
             map.iter()
+                .filter(|(k, _)| *k != DetailVisitor::ROOT_ITEM)
                 .map(|(k, v)| {
                     (
                         k.clone(),
                         v.iter()
-                            .map(|(k2, set)| (k2.clone(), set.iter().cloned().collect::<Vec<_>>()))
+                            .filter(|(k2, _)| *k2 != DetailVisitor::ROOT_ITEM)
+                            .map(|(k2, set)| {
+                                (
+                                    k2.clone(),
+                                    set.iter()
+                                        .filter(|t| *t != DetailVisitor::ROOT_ITEM)
+                                        .cloned()
+                                        .collect::<Vec<_>>(),
+                                )
+                            })
+                            .filter(|(_, v)| !v.is_empty())
                             .collect::<HashMap<_, _>>(),
                     )
                 })
+                .filter(|(_, v)| !v.is_empty())
                 .collect::<HashMap<_, _>>()
         };
 

--- a/cargo-anatomy/tests/cli.rs
+++ b/cargo-anatomy/tests/cli.rs
@@ -917,6 +917,35 @@ fn external_crate_excluded_without_x() {
 }
 
 #[test]
+fn no_crate_root_in_outputs() {
+    let dir = create_workspace(&[
+        ("a", "use b::Foo; pub struct A;\n"),
+        ("b", "pub struct Foo;\n"),
+    ]);
+
+    let mut cmd = Command::cargo_bin("cargo-anatomy").unwrap();
+    cmd.args(["-a", "-o", "json", "--show-types-crates", "a,b", "-x"])
+        .current_dir(dir.path());
+    let out = cmd.assert().get_output().stdout.clone();
+    let s = String::from_utf8_lossy(&out);
+    assert!(!s.contains("__crate_root"));
+
+    let mut cmd = Command::cargo_bin("cargo-anatomy").unwrap();
+    cmd.args(["-a", "-o", "mermaid", "--show-types-crates", "a,b", "-x"])
+        .current_dir(dir.path());
+    let out = cmd.assert().get_output().stdout.clone();
+    let s = String::from_utf8_lossy(&out);
+    assert!(!s.contains("__crate_root"));
+
+    let mut cmd = Command::cargo_bin("cargo-anatomy").unwrap();
+    cmd.args(["-a", "-o", "dot", "--show-types-crates", "a,b", "-x"])
+        .current_dir(dir.path());
+    let out = cmd.assert().get_output().stdout.clone();
+    let s = String::from_utf8_lossy(&out);
+    assert!(!s.contains("__crate_root"));
+}
+
+#[test]
 fn custom_config_thresholds() {
     let dir = create_workspace(&[("pkg", "pub trait T {} pub struct S;\n")]);
     let config = r#"


### PR DESCRIPTION
## Summary
- filter out `__crate_root` when building crate details
- add regression test ensuring the root item is absent in JSON, Mermaid and Dot outputs

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo test`
- `cargo tarpaulin --workspace --timeout 120` *(fails coverage <90%)*

------
https://chatgpt.com/codex/tasks/task_b_688aec77e9c0832ba132a0a8fac88f99