### PR TITLE
Bump version to 0.6.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-anatomy"
-version = "0.6.0-rc2"
+version = "0.6.0"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See [docs/output-schema.md](https://github.com/cutsea110/cargo-anatomy/blob/main
 ```json
 {
   "meta": {
-  "cargo-anatomy": { "version": "0.6.0-rc2", "target": "linux/x86_64" },
+  "cargo-anatomy": { "version": "0.6.0", "target": "linux/x86_64" },
     "config": {
       "evaluation": {
         "abstraction": { "abstract_min": 0.7, "concrete_max": 0.3 },

--- a/cargo-anatomy/CHANGELOG.md
+++ b/cargo-anatomy/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.0] - 2025-07-31
+### Added
+- Type-level mermaid and Graphviz DOT output with crate filters.
+- Function nodes included in Mermaid graphs.
+- CLI thresholds configurable via `.anatomy.toml`.
+### Changed
+- Argument parsing switched to clap.
+- Removed crate root nodes from graphs.
+- Default configuration uses workspace `.anatomy.toml`.
+### Fixed
+- Correct handling when invoked as a cargo subcommand.
+
 ## [0.5.2] - 2025-07-23
 ### Fixed
 - Improved workspace dependency detection for glob and macro imports.

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-anatomy"
-version = "0.6.0-rc2"
+version = "0.6.0"
 edition = "2021"
 authors = ["Katsutoshi Itoh"]
 description = "Analyze Rust workspaces and report package metrics"

--- a/docs/output-schema.md
+++ b/docs/output-schema.md
@@ -69,7 +69,7 @@ The following is a shortened example after running `cargo anatomy -a | jq`:
 ```json
 {
   "meta": {
-  "cargo-anatomy": { "version": "0.6.0-rc2", "target": "linux/x86_64" },
+  "cargo-anatomy": { "version": "0.6.0", "target": "linux/x86_64" },
     "config": {
       "evaluation": {
         "abstraction": { "abstract_min": 0.7, "concrete_max": 0.3 },


### PR DESCRIPTION
## Summary
- release cargo-anatomy 0.6.0
- document the release in CHANGELOG
- update version references in docs and README

## Testing
- `cargo fmt --all`
- `cargo clippy -- -D warnings`
- `cargo build`
- `cargo test`
- `cargo tarpaulin --out Xml` *(fails: 56.69% coverage)*

------
https://chatgpt.com/codex/tasks/task_b_688c2c516d8c832bb93d9a100340d22e