### PR TITLE
chore: release 0.6.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -111,7 +111,7 @@ dependencies = [
 
 [[package]]
 name = "cargo-anatomy"
-version = "0.6.1"
+version = "0.6.2"
 dependencies = [
  "assert_cmd",
  "cargo_metadata",

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ See [docs/output-schema.md](https://github.com/cutsea110/cargo-anatomy/blob/main
 ```json
 {
   "meta": {
-  "cargo-anatomy": { "version": "0.6.1", "target": "linux/x86_64" },
+  "cargo-anatomy": { "version": "0.6.2", "target": "linux/x86_64" },
     "config": {
       "evaluation": {
         "abstraction": { "abstract_min": 0.7, "concrete_max": 0.3 },

--- a/cargo-anatomy/CHANGELOG.md
+++ b/cargo-anatomy/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.6.2] - 2025-08-14
+### Maintenance
+- Routine maintenance release.
+
 ## [0.6.1] - 2025-08-13
 ### Maintenance
 - Routine maintenance release.

--- a/cargo-anatomy/Cargo.toml
+++ b/cargo-anatomy/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cargo-anatomy"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2021"
 authors = ["Katsutoshi Itoh"]
 description = "Analyze Rust workspaces and report package metrics"

--- a/docs/output-schema.md
+++ b/docs/output-schema.md
@@ -69,7 +69,7 @@ The following is a shortened example after running `cargo anatomy -a | jq`:
 ```json
 {
   "meta": {
-  "cargo-anatomy": { "version": "0.6.1", "target": "linux/x86_64" },
+  "cargo-anatomy": { "version": "0.6.2", "target": "linux/x86_64" },
     "config": {
       "evaluation": {
         "abstraction": { "abstract_min": 0.7, "concrete_max": 0.3 },


### PR DESCRIPTION
## Summary
- bump version to 0.6.2
- document maintenance release in changelog
- update docs to reference 0.6.2

## Testing
- `cargo fmt --all`
- `cargo build`
- `cargo clippy -- -D warnings`
- `cargo test`
- `cargo tarpaulin --out Xml` *(55.65% coverage)*

------
https://chatgpt.com/codex/tasks/task_b_68b51a35c738832ba4d766526828e790